### PR TITLE
Add some missing absolute module paths

### DIFF
--- a/strum_macros/src/enum_iter.rs
+++ b/strum_macros/src/enum_iter.rs
@@ -74,12 +74,12 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
             marker: ::std::marker::PhantomData #phantom_data,
         }
 
-        impl #impl_generics strum::IntoEnumIterator for #name #ty_generics #where_clause {
+        impl #impl_generics ::strum::IntoEnumIterator for #name #ty_generics #where_clause {
             type Iterator = #iter_name #ty_generics;
             fn iter() -> #iter_name #ty_generics {
                 #iter_name {
                     idx:0,
-                    marker: std::marker::PhantomData,
+                    marker: ::std::marker::PhantomData,
                 }
             }
         }


### PR DESCRIPTION
I was getting:

```Use of undeclared type or module `strum` ``` and

```Use of undeclared type or module `std` ```

so I dug into the source and found these.

I'm not super familiar with procedural macros, I just made them follow the pattern for the rest of the file, apologies if there's subtlety I'm missing.