### PR TITLE
Fix associated type in example generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Strum has implemented the following macros:
     impl std::str::FromStr for Color {
         type Err = ::strum::ParseError;
 
-        fn from_str(s: &str) -> ::std::result::Result<Color, Self::Error> {
+        fn from_str(s: &str) -> ::std::result::Result<Color, Self::Err> {
             match s {
                 "Red" => ::std::result::Result::Ok(Color::Red),
                 "Green" => ::std::result::Result::Ok(Color::Green { range:Default::default() }),

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -66,7 +66,7 @@
 //!     impl ::std::str::FromStr for Color {
 //!         type Err = ::strum::ParseError;
 //!
-//!         fn from_str(s: &str) -> ::std::result::Result<Color, Self::Error> {
+//!         fn from_str(s: &str) -> ::std::result::Result<Color, Self::Err> {
 //!             match s {
 //!                 "Red" => ::std::result::Result::Ok(Color::Red),
 //!                 "Green" => ::std::result::Result::Ok(Color::Green { range:Default::default() }),


### PR DESCRIPTION
Fix to match `type Err`