### PR TITLE
Implement Clone trait for enum iterators.

### DIFF
--- a/strum_macros/src/enum_iter.rs
+++ b/strum_macros/src/enum_iter.rs
@@ -108,5 +108,14 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
                 self.size_hint().0
             }
         }
+
+        impl #impl_generics Clone for #iter_name #ty_generics #where_clause {
+            fn clone(&self) -> #iter_name #ty_generics {
+                #iter_name {
+                    idx: self.idx,
+                    marker: self.marker.clone(),
+                }
+            }
+        }
     }
 }

--- a/strum_tests/tests/enum_iter.rs
+++ b/strum_tests/tests/enum_iter.rs
@@ -60,3 +60,37 @@ fn len_test() {
 
     assert_eq!(0, i.len());
 }
+
+#[test]
+fn clone_test() {
+    let mut i = Week::iter();
+    i.next();
+    i.next();
+
+    let mut i_cloned = i.clone();
+
+    assert_eq!(Some(Week::Tuesday), i.next());
+    assert_eq!(Some(Week::Tuesday), i_cloned.next());
+
+    i.next();
+    i.next();
+
+    assert_eq!(Some(Week::Friday), i.next());
+    assert_eq!(Some(Week::Wednesday), i_cloned.next());
+}
+
+#[test]
+fn cycle_test() {
+    let results = Week::iter().cycle().take(10).collect::<Vec<_>>();
+    let expected = vec![Week::Sunday,
+                        Week::Monday,
+                        Week::Tuesday,
+                        Week::Wednesday,
+                        Week::Thursday,
+                        Week::Friday,
+                        Week::Saturday,
+                        Week::Sunday,
+                        Week::Monday,
+                        Week::Tuesday];
+    assert_eq!(expected, results);
+}


### PR DESCRIPTION
I implemented the `Clone` trait for enum iterators, this enables [`cycle()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.cycle). I have added tests for both `clone()` and `cycle()`.