### PR TITLE
Bump dependencies (mainly `syn` crate)

### DIFF
--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -17,5 +17,5 @@ proc-macro = true
 name = "strum_macros"
 
 [dependencies]
-quote = "0.3.12"
-syn = "0.11.4"
+quote = "0.5.2"
+syn = { version = "0.13.7", features = ["parsing"] }

--- a/strum_macros/src/display.rs
+++ b/strum_macros/src/display.rs
@@ -2,7 +2,7 @@
 use quote;
 use syn;
 
-use helpers::{unique_attr, extract_attrs, is_disabled};
+use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
 
 pub fn display_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
@@ -16,16 +16,17 @@ pub fn display_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     for variant in variants {
         use syn::Fields::*;
         let ident = &variant.ident;
+        let meta = extract_meta(&variant.attrs);
 
-        if is_disabled(&variant.attrs) {
+        if is_disabled(&meta) {
             continue;
         }
 
         // Look at all the serialize attributes.
-        let output = if let Some(n) = unique_attr(&variant.attrs, "strum", "to_string") {
+        let output = if let Some(n) = unique_attr(&meta, "strum", "to_string") {
             n
         } else {
-            let mut attrs = extract_attrs(&variant.attrs, "strum", "serialize");
+            let mut attrs = extract_attrs(&meta, "strum", "serialize");
             // We always take the longest one. This is arbitary, but is *mostly* deterministic
             attrs.sort_by_key(|s| s.len());
             if let Some(n) = attrs.pop() {

--- a/strum_macros/src/display.rs
+++ b/strum_macros/src/display.rs
@@ -7,14 +7,14 @@ use helpers::{unique_attr, extract_attrs, is_disabled};
 pub fn display_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-    let variants = match ast.body {
-        syn::Body::Enum(ref v) => v,
+    let variants = match ast.data {
+        syn::Data::Enum(ref v) => &v.variants,
         _ => panic!("Display only works on Enums"),
     };
 
     let mut arms = Vec::new();
     for variant in variants {
-        use syn::VariantData::*;
+        use syn::Fields::*;
         let ident = &variant.ident;
 
         if is_disabled(&variant.attrs) {
@@ -27,18 +27,18 @@ pub fn display_inner(ast: &syn::DeriveInput) -> quote::Tokens {
         } else {
             let mut attrs = extract_attrs(&variant.attrs, "strum", "serialize");
             // We always take the longest one. This is arbitary, but is *mostly* deterministic
-            attrs.sort_by_key(|s| -(s.len() as isize));
-            if let Some(n) = attrs.first() {
+            attrs.sort_by_key(|s| s.len());
+            if let Some(n) = attrs.pop() {
                 n
             } else {
-                ident.as_ref()
+                ident.to_string()
             }
         };
 
-        let params = match variant.data {
-            Unit => quote::Ident::from(""),
-            Tuple(..) => quote::Ident::from("(..)"),
-            Struct(..) => quote::Ident::from("{..}"),
+        let params = match variant.fields {
+            Unit => quote!{},
+            Unnamed(..) => quote!{ (..) },
+            Named(..) => quote!{ {..} },
         };
 
         arms.push(quote!{ #name::#ident #params => f.write_str(#output) });

--- a/strum_macros/src/enum_iter.rs
+++ b/strum_macros/src/enum_iter.rs
@@ -9,23 +9,20 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let (impl_generics, ty_generics, where_clause) = gen.split_for_impl();
     let vis = &ast.vis;
 
-    if gen.lifetimes.len() > 0 {
+    if gen.lifetimes().count() > 0 {
         panic!("Enum Iterator isn't supported on Enums with lifetimes. The resulting enums would \
                  be unbounded.");
     }
 
-    let phantom_data = if gen.ty_params.len() > 0 {
-        let g = gen.ty_params
-            .iter()
-            .map(|param| &param.ident)
-            .collect::<Vec<_>>();
-        quote!{ < ( #(#g),* ) > }
+    let phantom_data = if gen.type_params().count() > 0 {
+        let g = gen.type_params().map(|param| &param.ident);
+        quote! { < ( #(#g),* ) > }
     } else {
         quote! { < () > }
     };
 
-    let variants = match ast.body {
-        syn::Body::Enum(ref v) => v,
+    let variants = match ast.data {
+        syn::Data::Enum(ref v) => &v.variants,
         _ => panic!("EnumIter only works on Enums"),
     };
 
@@ -35,31 +32,18 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
         .filter(|variant| !is_disabled(&variant.attrs));
 
     for (idx, variant) in enabled.enumerate() {
-        use syn::VariantData::*;
+        use syn::Fields::*;
         let ident = &variant.ident;
-        let params = match variant.data {
-            Unit => quote::Ident::from(""),
-            Tuple(ref fields) => {
-                let default = fields
-                    .iter()
-                    .map(|_| "::std::default::Default::default()")
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                quote::Ident::from(&*format!("({})", default))
+        let params = match variant.fields {
+            Unit => quote!{},
+            Unnamed(ref fields) => {
+                let defaults = ::std::iter::repeat(quote!(::std::default::Default::default()))
+                    .take(fields.unnamed.len());
+                quote! { (#(#defaults),*) }
             }
-            Struct(ref fields) => {
-                let default = fields
-                    .iter()
-                    .map(|field| {
-                             format!("{}: {}",
-                                     field.ident.as_ref().unwrap(),
-                                     "::std::default::Default::default()")
-                         })
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                quote::Ident::from(&*format!("{{{}}}", default))
+            Named(ref fields) => {
+                let fields = fields.named.iter().map(|field| field.ident.unwrap());
+                quote! { {#(#fields: ::std::default::Default::default()),*} }
             }
         };
 
@@ -68,7 +52,7 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
 
     let variant_count = arms.len();
     arms.push(quote! { _ => ::std::option::Option::None });
-    let iter_name = quote::Ident::from(&*format!("{}Iter", name));
+    let iter_name = syn::parse_str::<syn::Ident>(&format!("{}Iter", name)).unwrap();
     quote!{
         #vis struct #iter_name #ty_generics {
             idx: usize,
@@ -84,10 +68,10 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
                 }
             }
         }
-        
+
         impl #impl_generics Iterator for #iter_name #ty_generics #where_clause {
             type Item = #name #ty_generics;
-            
+
             fn next(&mut self) -> Option<#name #ty_generics> {
                 let output = match self.idx {
                     #(#arms),*

--- a/strum_macros/src/enum_iter.rs
+++ b/strum_macros/src/enum_iter.rs
@@ -1,7 +1,7 @@
 use quote;
 use syn;
 
-use helpers::is_disabled;
+use helpers::{extract_meta, is_disabled};
 
 pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
@@ -29,7 +29,7 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let mut arms = Vec::new();
     let enabled = variants
         .iter()
-        .filter(|variant| !is_disabled(&variant.attrs));
+        .filter(|variant| !is_disabled(&extract_meta(&variant.attrs)));
 
     for (idx, variant) in enabled.enumerate() {
         use syn::Fields::*;

--- a/strum_macros/src/enum_messages.rs
+++ b/strum_macros/src/enum_messages.rs
@@ -1,7 +1,7 @@
 use quote;
 use syn;
 
-use helpers::{unique_attr, extract_attrs, is_disabled};
+use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
 
 pub fn enum_message_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
@@ -16,8 +16,9 @@ pub fn enum_message_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let mut serializations = Vec::new();
 
     for variant in variants {
-        let messages = unique_attr(&variant.attrs, "strum", "message");
-        let detailed_messages = unique_attr(&variant.attrs, "strum", "detailed_message");
+        let meta = extract_meta(&variant.attrs);
+        let messages = unique_attr(&meta, "strum", "message");
+        let detailed_messages = unique_attr(&meta, "strum", "detailed_message");
         let ident = &variant.ident;
 
         use syn::Fields::*;
@@ -29,7 +30,7 @@ pub fn enum_message_inner(ast: &syn::DeriveInput) -> quote::Tokens {
 
         // You can't disable getting the serializations.
         {
-            let mut serialization_variants = extract_attrs(&variant.attrs, "strum", "serialize");
+            let mut serialization_variants = extract_attrs(&meta, "strum", "serialize");
             if serialization_variants.len() == 0 {
                 serialization_variants.push(ident.to_string());
             }
@@ -44,7 +45,7 @@ pub fn enum_message_inner(ast: &syn::DeriveInput) -> quote::Tokens {
         }
 
         // But you can disable the messages.
-        if is_disabled(&variant.attrs) {
+        if is_disabled(&meta) {
             continue;
         }
 

--- a/strum_macros/src/from_string.rs
+++ b/strum_macros/src/from_string.rs
@@ -7,8 +7,8 @@ use helpers::{unique_attr, extract_attrs, is_disabled};
 pub fn from_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-    let variants = match ast.body {
-        syn::Body::Enum(ref v) => v,
+    let variants = match ast.data {
+        syn::Data::Enum(ref v) => &v.variants,
         _ => panic!("FromString only works on Enums"),
     };
 
@@ -17,7 +17,7 @@ pub fn from_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
         quote! { _ => ::std::result::Result::Err(::strum::ParseError::VariantNotFound) };
     let mut arms = Vec::new();
     for variant in variants {
-        use syn::VariantData::*;
+        use syn::Fields::*;
         let ident = &variant.ident;
 
         // Look at all the serialize attributes.
@@ -27,13 +27,13 @@ pub fn from_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
             continue;
         }
 
-        if let Some("true") = unique_attr(&variant.attrs, "strum", "default") {
+        if unique_attr(&variant.attrs, "strum", "default").map_or(false, |s| s == "true") {
             if has_default {
                 panic!("Can't have multiple default variants");
             }
 
-            if let Tuple(ref fields) = variant.data {
-                if fields.len() != 1 {
+            if let Unnamed(ref fields) = variant.fields {
+                if fields.unnamed.len() != 1 {
                     panic!("Default only works on unit structs with a single String parameter");
                 }
 
@@ -50,30 +50,19 @@ pub fn from_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
 
         // If we don't have any custom variants, add the default name.
         if attrs.len() == 0 {
-            attrs.push(ident.as_ref());
+            attrs.push(ident.to_string());
         }
 
-        let params = match variant.data {
-            Unit => quote::Ident::from(""),
-            Tuple(ref fields) => {
-                let default = fields
-                    .iter()
-                    .map(|_| "Default::default()")
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                quote::Ident::from(&*format!("({})", default))
+        let params = match variant.fields {
+            Unit => quote!{},
+            Unnamed(ref fields) => {
+                let defaults = ::std::iter::repeat(quote!(Default::default()))
+                    .take(fields.unnamed.len());
+                quote! { (#(#defaults),*) }
             }
-            Struct(ref fields) => {
-                let default = fields
-                    .iter()
-                    .map(|field| {
-                             format!("{}:{}", field.ident.as_ref().unwrap(), "Default::default()")
-                         })
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                quote::Ident::from(&*format!("{{{}}}", default))
+            Named(ref fields) => {
+                let fields = fields.named.iter().map(|field| field.ident.unwrap());
+                quote! { {#(#fields: Default::default()),*} }
             }
         };
 

--- a/strum_macros/src/from_string.rs
+++ b/strum_macros/src/from_string.rs
@@ -2,7 +2,7 @@
 use quote;
 use syn;
 
-use helpers::{unique_attr, extract_attrs, is_disabled};
+use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
 
 pub fn from_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
@@ -19,15 +19,16 @@ pub fn from_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     for variant in variants {
         use syn::Fields::*;
         let ident = &variant.ident;
+        let meta = extract_meta(&variant.attrs);
 
         // Look at all the serialize attributes.
-        let mut attrs = extract_attrs(&variant.attrs, "strum", "serialize");
-        attrs.extend(extract_attrs(&variant.attrs, "strum", "to_string"));
-        if is_disabled(&variant.attrs) {
+        let mut attrs = extract_attrs(&meta, "strum", "serialize");
+        attrs.extend(extract_attrs(&meta, "strum", "to_string"));
+        if is_disabled(&meta) {
             continue;
         }
 
-        if unique_attr(&variant.attrs, "strum", "default").map_or(false, |s| s == "true") {
+        if unique_attr(&meta, "strum", "default").map_or(false, |s| s == "true") {
             if has_default {
                 panic!("Can't have multiple default variants");
             }

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -42,70 +42,63 @@ fn debug_print_generated(ast: &syn::DeriveInput, toks: &quote::Tokens) {
 
 #[proc_macro_derive(EnumString,attributes(strum))]
 pub fn from_string(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_derive_input(&s).unwrap();
+    let ast = syn::parse(input).unwrap();
 
     let toks = from_string::from_string_inner(&ast);
     debug_print_generated(&ast, &toks);
-    toks.parse().unwrap()
+    toks.into()
 }
 
 #[proc_macro_derive(AsRefStr,attributes(strum))]
 pub fn as_ref_str(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_derive_input(&s).unwrap();
+    let ast = syn::parse(input).unwrap();
 
     let toks = as_ref_str::as_ref_str_inner(&ast);
     debug_print_generated(&ast, &toks);
-    toks.parse().unwrap()
+    toks.into()
 }
 
 #[proc_macro_derive(ToString,attributes(strum))]
 pub fn to_string(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_derive_input(&s).unwrap();
+    let ast = syn::parse(input).unwrap();
 
     let toks = to_string::to_string_inner(&ast);
     debug_print_generated(&ast, &toks);
-    toks.parse().unwrap()
+    toks.into()
 }
 
 #[proc_macro_derive(Display,attributes(strum))]
 pub fn display(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_derive_input(&s).unwrap();
+    let ast = syn::parse(input).unwrap();
 
     let toks = display::display_inner(&ast);
     debug_print_generated(&ast, &toks);
-    toks.parse().unwrap()
+    toks.into()
 }
 
 #[proc_macro_derive(EnumIter,attributes(strum))]
 pub fn enum_iter(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_derive_input(&s).unwrap();
+    let ast = syn::parse(input).unwrap();
 
     let toks = enum_iter::enum_iter_inner(&ast);
     debug_print_generated(&ast, &toks);
-    toks.parse().unwrap()
+    toks.into()
 }
 
 #[proc_macro_derive(EnumMessage,attributes(strum))]
 pub fn enum_messages(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_derive_input(&s).unwrap();
+    let ast = syn::parse(input).unwrap();
 
     let toks = enum_messages::enum_message_inner(&ast);
     debug_print_generated(&ast, &toks);
-    toks.parse().unwrap()
+    toks.into()
 }
 
 #[proc_macro_derive(EnumProperty,attributes(strum))]
 pub fn enum_properties(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_derive_input(&s).unwrap();
+    let ast = syn::parse(input).unwrap();
 
     let toks = enum_properties::enum_properties_inner(&ast);
     debug_print_generated(&ast, &toks);
-    toks.parse().unwrap()
+    toks.into()
 }

--- a/strum_macros/src/to_string.rs
+++ b/strum_macros/src/to_string.rs
@@ -7,14 +7,14 @@ use helpers::{unique_attr, extract_attrs, is_disabled};
 pub fn to_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-    let variants = match ast.body {
-        syn::Body::Enum(ref v) => v,
+    let variants = match ast.data {
+        syn::Data::Enum(ref v) => &v.variants,
         _ => panic!("ToString only works on Enums"),
     };
 
     let mut arms = Vec::new();
     for variant in variants {
-        use syn::VariantData::*;
+        use syn::Fields::*;
         let ident = &variant.ident;
 
         if is_disabled(&variant.attrs) {
@@ -27,18 +27,18 @@ pub fn to_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
         } else {
             let mut attrs = extract_attrs(&variant.attrs, "strum", "serialize");
             // We always take the longest one. This is arbitary, but is *mostly* deterministic
-            attrs.sort_by_key(|s| -(s.len() as isize));
-            if let Some(n) = attrs.first() {
+            attrs.sort_by_key(|s| s.len());
+            if let Some(n) = attrs.pop() {
                 n
             } else {
-                ident.as_ref()
+                ident.to_string()
             }
         };
 
-        let params = match variant.data {
-            Unit => quote::Ident::from(""),
-            Tuple(..) => quote::Ident::from("(..)"),
-            Struct(..) => quote::Ident::from("{..}"),
+        let params = match variant.fields {
+            Unit => quote!{},
+            Unnamed(..) => quote!{ (..) },
+            Named(..) => quote!{ {..} },
         };
 
         arms.push(quote!{ #name::#ident #params => ::std::string::String::from(#output) });

--- a/strum_macros/src/to_string.rs
+++ b/strum_macros/src/to_string.rs
@@ -2,7 +2,7 @@
 use quote;
 use syn;
 
-use helpers::{unique_attr, extract_attrs, is_disabled};
+use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
 
 pub fn to_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
@@ -16,16 +16,17 @@ pub fn to_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     for variant in variants {
         use syn::Fields::*;
         let ident = &variant.ident;
+        let meta = extract_meta(&variant.attrs);
 
-        if is_disabled(&variant.attrs) {
+        if is_disabled(&meta) {
             continue;
         }
 
         // Look at all the serialize attributes.
-        let output = if let Some(n) = unique_attr(&variant.attrs, "strum", "to_string") {
+        let output = if let Some(n) = unique_attr(&meta, "strum", "to_string") {
             n
         } else {
-            let mut attrs = extract_attrs(&variant.attrs, "strum", "serialize");
+            let mut attrs = extract_attrs(&meta, "strum", "serialize");
             // We always take the longest one. This is arbitary, but is *mostly* deterministic
             attrs.sort_by_key(|s| s.len());
             if let Some(n) = attrs.pop() {


### PR DESCRIPTION
This pull request bumps dependencies.

Newer versions of `syn` and `quote` crates are available, and there are some breaking changes from syn-0.11 to syn-0.13.