### PR TITLE
Disable `missing_docs` lint for new types created by `EnumIter`

### DIFF
--- a/strum_macros/src/enum_iter.rs
+++ b/strum_macros/src/enum_iter.rs
@@ -54,6 +54,7 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
     arms.push(quote! { _ => ::std::option::Option::None });
     let iter_name = syn::parse_str::<syn::Ident>(&format!("{}Iter", name)).unwrap();
     quote!{
+        #[allow(missing_docs)]
         #vis struct #iter_name #ty_generics {
             idx: usize,
             marker: ::std::marker::PhantomData #phantom_data,


### PR DESCRIPTION
New structs generated by `derive(EnumIter)` caused `warning: missing documentation for a struct` warning on my environment (rustc 1.28.0-nightly (cb20f68d0 2018-05-21)).

I don't know whether this behavior (lint enabled for automatically generated code which users may not be responsible) will change later or not, but I think it is not so bad if these lints are automatically disabled for automatically generated codes.