### PR TITLE
Bump dependencies (`syn` and `quote`)

### DIFF
--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -17,5 +17,6 @@ proc-macro = true
 name = "strum_macros"
 
 [dependencies]
-quote = "0.5.2"
-syn = { version = "0.13.7", features = ["parsing"] }
+proc-macro2 = "0.4"
+quote = "0.6"
+syn = { version = "0.14", features = ["parsing"] }

--- a/strum_macros/src/as_ref_str.rs
+++ b/strum_macros/src/as_ref_str.rs
@@ -1,10 +1,9 @@
-
-use quote;
+use proc_macro2::TokenStream;
 use syn;
 
 use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
 
-pub fn as_ref_str_inner(ast: &syn::DeriveInput) -> quote::Tokens {
+pub fn as_ref_str_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let variants = match ast.data {

--- a/strum_macros/src/display.rs
+++ b/strum_macros/src/display.rs
@@ -1,10 +1,9 @@
-
-use quote;
+use proc_macro2::TokenStream;
 use syn;
 
 use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
 
-pub fn display_inner(ast: &syn::DeriveInput) -> quote::Tokens {
+pub fn display_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let variants = match ast.data {

--- a/strum_macros/src/enum_iter.rs
+++ b/strum_macros/src/enum_iter.rs
@@ -1,9 +1,9 @@
-use quote;
+use proc_macro2::TokenStream;
 use syn;
 
 use helpers::{extract_meta, is_disabled};
 
-pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
+pub fn enum_iter_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let gen = &ast.generics;
     let (impl_generics, ty_generics, where_clause) = gen.split_for_impl();
@@ -42,7 +42,7 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> quote::Tokens {
                 quote! { (#(#defaults),*) }
             }
             Named(ref fields) => {
-                let fields = fields.named.iter().map(|field| field.ident.unwrap());
+                let fields = fields.named.iter().map(|field| field.ident.as_ref().unwrap());
                 quote! { {#(#fields: ::std::default::Default::default()),*} }
             }
         };

--- a/strum_macros/src/enum_messages.rs
+++ b/strum_macros/src/enum_messages.rs
@@ -1,9 +1,9 @@
-use quote;
+use proc_macro2::TokenStream;
 use syn;
 
 use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
 
-pub fn enum_message_inner(ast: &syn::DeriveInput) -> quote::Tokens {
+pub fn enum_message_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let variants = match ast.data {

--- a/strum_macros/src/enum_properties.rs
+++ b/strum_macros/src/enum_properties.rs
@@ -1,4 +1,4 @@
-use quote;
+use proc_macro2::TokenStream;
 use syn;
 use syn::Meta;
 
@@ -39,7 +39,7 @@ fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
         .collect()
 }
 
-pub fn enum_properties_inner(ast: &syn::DeriveInput) -> quote::Tokens {
+pub fn enum_properties_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let variants = match ast.data {
@@ -68,7 +68,7 @@ pub fn enum_properties_inner(ast: &syn::DeriveInput) -> quote::Tokens {
 
         for (key, value) in extract_properties(&meta) {
             use syn::Lit::*;
-            let key = key.as_ref();
+            let key = key.to_string();
             match value {
                 Str(ref s, ..) => {
                     string_arms.push(quote!{ #key => ::std::option::Option::Some( #s )})

--- a/strum_macros/src/from_string.rs
+++ b/strum_macros/src/from_string.rs
@@ -1,10 +1,9 @@
-
-use quote;
+use proc_macro2::TokenStream;
 use syn;
 
 use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
 
-pub fn from_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
+pub fn from_string_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let variants = match ast.data {
@@ -62,7 +61,7 @@ pub fn from_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
                 quote! { (#(#defaults),*) }
             }
             Named(ref fields) => {
-                let fields = fields.named.iter().map(|field| field.ident.unwrap());
+                let fields = fields.named.iter().map(|field| field.ident.as_ref().unwrap());
                 quote! { {#(#fields: Default::default()),*} }
             }
         };

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -13,6 +13,7 @@ extern crate syn;
 #[macro_use]
 extern crate quote;
 extern crate proc_macro;
+extern crate proc_macro2;
 
 mod helpers;
 mod as_ref_str;
@@ -23,25 +24,24 @@ mod enum_iter;
 mod enum_messages;
 mod enum_properties;
 
-use proc_macro::TokenStream;
 use std::env;
+use proc_macro2::TokenStream;
 
-fn debug_print_generated(ast: &syn::DeriveInput, toks: &quote::Tokens) {
-    let ident = ast.ident.as_ref();
+fn debug_print_generated(ast: &syn::DeriveInput, toks: &TokenStream) {
     let debug = env::var("STRUM_DEBUG");
     if let Ok(s) = debug {
         if s == "1" {
             println!("{}", toks);
         }
 
-        if s == ident {
+        if ast.ident == s {
             println!("{}", toks);
         }
     }
 }
 
 #[proc_macro_derive(EnumString,attributes(strum))]
-pub fn from_string(input: TokenStream) -> TokenStream {
+pub fn from_string(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
     let toks = from_string::from_string_inner(&ast);
@@ -50,7 +50,7 @@ pub fn from_string(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(AsRefStr,attributes(strum))]
-pub fn as_ref_str(input: TokenStream) -> TokenStream {
+pub fn as_ref_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
     let toks = as_ref_str::as_ref_str_inner(&ast);
@@ -59,7 +59,7 @@ pub fn as_ref_str(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(ToString,attributes(strum))]
-pub fn to_string(input: TokenStream) -> TokenStream {
+pub fn to_string(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
     let toks = to_string::to_string_inner(&ast);
@@ -68,7 +68,7 @@ pub fn to_string(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(Display,attributes(strum))]
-pub fn display(input: TokenStream) -> TokenStream {
+pub fn display(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
     let toks = display::display_inner(&ast);
@@ -77,7 +77,7 @@ pub fn display(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(EnumIter,attributes(strum))]
-pub fn enum_iter(input: TokenStream) -> TokenStream {
+pub fn enum_iter(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
     let toks = enum_iter::enum_iter_inner(&ast);
@@ -86,7 +86,7 @@ pub fn enum_iter(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(EnumMessage,attributes(strum))]
-pub fn enum_messages(input: TokenStream) -> TokenStream {
+pub fn enum_messages(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
     let toks = enum_messages::enum_message_inner(&ast);
@@ -95,7 +95,7 @@ pub fn enum_messages(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(EnumProperty,attributes(strum))]
-pub fn enum_properties(input: TokenStream) -> TokenStream {
+pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
     let toks = enum_properties::enum_properties_inner(&ast);

--- a/strum_macros/src/to_string.rs
+++ b/strum_macros/src/to_string.rs
@@ -1,10 +1,9 @@
-
-use quote;
+use proc_macro2::TokenStream;
 use syn;
 
 use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
 
-pub fn to_string_inner(ast: &syn::DeriveInput) -> quote::Tokens {
+pub fn to_string_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let variants = match ast.data {


### PR DESCRIPTION
syn-0.14 and quote-0.6 have been released, and they have breaking changes which affect `strum_macros` codes.