### PR TITLE
Feature/33/derive enum variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+* Serialization case can be controlled using `#[strum(serialize_all = "snake_case")]`. ([#21][#21])
+
+[#21]: https://github.com/Peternator7/strum/issues/21
+
+## 0.10.0
+
+### Added
+
+* Implemented `Clone` for `EnumIter`s. ([#18][#18])
+* Added `AsStaticRef` derive to allow enums to `impl AsStaticRef<str>`. ([#23][#23])
+
+### Fixed
+
+* `#[allow(missing_docs)]` on generated `EnumIter`s. ([#19][#19])
+
+[#18]: https://github.com/Peternator7/strum/pull/18
+[#19]: https://github.com/Peternator7/strum/issues/19
+[#23]: https://github.com/Peternator7/strum/issues/23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Added
 
 * Serialization case can be controlled using `#[strum(serialize_all = "snake_case")]`. ([#21][#21])
+* `#[derive(EnumDiscriminants)]` generates enum with variants without fields. ([#33][#33])
 
 [#21]: https://github.com/Peternator7/strum/issues/21
+[#33]: https://github.com/Peternator7/strum/issues/33
 
 ## 0.10.0
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,67 @@ Strum has implemented the following macros:
      }
      ```
 
+7. `EnumDiscriminants`: Given an enum named `MyEnum`, generates another enum called
+    `MyEnumDiscriminants` with the same variants, without any data fields. This is useful when you
+    wish to determine the variant of an enum from a String, but the variants contain any
+    non-`Default` fields. By default, the generated enum has the followign derives:
+    `Clone, Copy, Debug, PartialEq, Eq`. You can add additional derives using the
+    `#[strum_discriminants_derive(AdditionalDerive)]` attribute.
+
+    Here's an example:
+
+    ```rust
+    extern crate strum;
+    #[macro_use] extern crate strum_macros;
+
+    // Bring trait into scope
+    use std::str::FromStr;
+
+    #[derive(Debug)]
+    struct NonDefault;
+
+    #[allow(dead_code)]
+    #[derive(Debug, EnumDiscriminants)]
+    #[strum_discriminants_derive(EnumString)]
+    enum MyEnum {
+        Variant0(NonDefault),
+        Variant1 { a: NonDefault },
+    }
+
+    fn main() {
+        assert_eq!(
+            MyEnumDiscriminants::Variant0,
+            MyEnumDiscriminants::from_str("Variant0").unwrap()
+        );
+    }
+    ```
+
+    You can also rename the generated enum using the `#[strum_discriminants_name(OtherName)]`
+    attribute:
+
+    ```rust
+    extern crate strum;
+    #[macro_use] extern crate strum_macros;
+    // You need to bring the type into scope to use it!!!
+    use strum::IntoEnumIterator;
+
+    #[allow(dead_code)]
+    #[derive(Debug, EnumDiscriminants)]
+    #[strum_discriminants_derive(EnumIter)]
+    #[strum_discriminants_name(MyVariants)]
+    enum MyEnum {
+        Variant0(bool),
+        Variant1 { a: bool },
+    }
+
+    fn main() {
+        assert_eq!(
+            vec![MyVariants::Variant0, MyVariants::Variant1],
+            MyVariants::iter().collect::<Vec<_>>()
+        );
+    }
+    ```
+
 # Additional Attributes
 
 Strum supports several custom attributes to modify the generated code. At the enum level, the

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Strum has implemented the following macros:
     wish to determine the variant of an enum from a String, but the variants contain any
     non-`Default` fields. By default, the generated enum has the followign derives:
     `Clone, Copy, Debug, PartialEq, Eq`. You can add additional derives using the
-    `#[strum_discriminants_derive(AdditionalDerive)]` attribute.
+    `#[strum_discriminants(derive(AdditionalDerive))]` attribute.
 
     Here's an example:
 
@@ -317,7 +317,7 @@ Strum has implemented the following macros:
 
     #[allow(dead_code)]
     #[derive(Debug, EnumDiscriminants)]
-    #[strum_discriminants_derive(EnumString)]
+    #[strum_discriminants(derive(EnumString))]
     enum MyEnum {
         Variant0(NonDefault),
         Variant1 { a: NonDefault },
@@ -331,7 +331,7 @@ Strum has implemented the following macros:
     }
     ```
 
-    You can also rename the generated enum using the `#[strum_discriminants_name(OtherName)]`
+    You can also rename the generated enum using the `#[strum_discriminants(name(OtherName))]`
     attribute:
 
     ```rust
@@ -342,8 +342,8 @@ Strum has implemented the following macros:
 
     #[allow(dead_code)]
     #[derive(Debug, EnumDiscriminants)]
-    #[strum_discriminants_derive(EnumIter)]
-    #[strum_discriminants_name(MyVariants)]
+    #[strum_discriminants(derive(EnumIter))]
+    #[strum_discriminants(name(MyVariants))]
     enum MyEnum {
         Variant0(bool),
         Variant1 { a: bool },

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Cargo.toml. Strum_macros contains the macros needed to derive all the traits in 
 
 ```toml
 [dependencies]
-strum = "0.10.0"
-strum_macros = "0.10.0"
+strum = "0.11.0"
+strum_macros = "0.11.0"
 ```
 
 And add these lines to the root of your project, either lib.rs or main.rs.
@@ -91,10 +91,10 @@ Strum has implemented the following macros:
     */
     ```
 
-    Note that the implementation of `FromStr` only matches on the name of the variant.
-    Strum, where possible, avoids operations that have an unknown runtime cost, and parsing strings
-    is potentially an expensive operation. If you do need that behavior, consider the more powerful
-    Serde library for your serialization.
+    Note that the implementation of `FromStr` by default only matches on the name of the
+    variant. There is an option to match on different case conversions through the
+    `#[strum(serialize_all = "snake_case")]` type attribute. See the **Additional Attributes**
+    Section for more information on using this feature.
 
 2. `Display` / `ToString`: prints out the given enum. This enables you to perform round trip
     style conversions from enum into string and back again for unit style variants. `ToString` and 
@@ -298,8 +298,43 @@ Strum has implemented the following macros:
 
 # Additional Attributes
 
-Strum supports several custom attributes to modify the generated code. Custom attributes are
-applied to a variant by adding #[strum(parameter="value")] to the variant.
+Strum supports several custom attributes to modify the generated code. At the enum level, the
+`#[strum(serialize_all = "snake_case")]` attribute can be used to change the case used when
+serializing to and deserializing from strings:
+
+```rust
+extern crate strum;
+#[macro_use]
+extern crate strum_macros;
+
+#[derive(Debug, Eq, PartialEq, ToString)]
+#[strum(serialize_all = "snake_case")]
+enum Brightness {
+    DarkBlack,
+    Dim {
+        glow: usize,
+    },
+    #[strum(serialize = "bright")]
+    BrightWhite,
+}
+
+fn main() {
+    assert_eq!(
+        String::from("dark_black"),
+        Brightness::DarkBlack.to_string().as_ref()
+    );
+    assert_eq!(
+        String::from("dim"),
+        Brightness::Dim { glow: 0 }.to_string().as_ref()
+    );
+    assert_eq!(
+        String::from("bright"),
+        Brightness::BrightWhite.to_string().as_ref()
+    );
+}
+```
+
+Custom attributes are applied to a variant by adding `#[strum(parameter="value")]` to the variant.
 
 - `serialize="..."`: Changes the text that `FromStr()` looks for when parsing a string. This attribute can
    be applied multiple times to an element and the enum variant will be parsed if any of them match.

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Strum has implemented the following macros:
 7. `EnumDiscriminants`: Given an enum named `MyEnum`, generates another enum called
     `MyEnumDiscriminants` with the same variants, without any data fields. This is useful when you
     wish to determine the variant of an enum from a String, but the variants contain any
-    non-`Default` fields. By default, the generated enum has the followign derives:
+    non-`Default` fields. By default, the generated enum has the following derives:
     `Clone, Copy, Debug, PartialEq, Eq`. You can add additional derives using the
     `#[strum_discriminants(derive(AdditionalDerive))]` attribute.
 
@@ -354,6 +354,29 @@ Strum has implemented the following macros:
             vec![MyVariants::Variant0, MyVariants::Variant1],
             MyVariants::iter().collect::<Vec<_>>()
         );
+    }
+    ```
+
+    The derived enum also has the following trait implementations:
+
+    * `impl From<MyEnum> for MyEnumDiscriminants`
+    * `impl<'_enum> From<&'_enum MyEnum> for MyEnumDiscriminants`
+
+    These allow you to get the *Discriminants* enum variant from the original enum:
+
+    ```rust
+    extern crate strum;
+    #[macro_use] extern crate strum_macros;
+
+    #[derive(Debug, EnumDiscriminants)]
+    #[strum_discriminants(name(MyVariants))]
+    enum MyEnum {
+        Variant0(bool),
+        Variant1 { a: bool },
+    }
+
+    fn main() {
+        assert_eq!(MyVariants::Variant0, MyEnum::Variant0(true).into());
     }
     ```
 

--- a/strum/Cargo.toml
+++ b/strum/Cargo.toml
@@ -13,8 +13,7 @@ homepage = "https://github.com/Peternator7/strum"
 readme = "../README.md"
 
 [dev-dependencies]
-strum_macros = "0.10.0"
-# strum_macros = { path = "../strum_macros" }
+strum_macros = { path = "../strum_macros", version = "0.10.0" }
 
 [badges]
 travis-ci = { repository = "Peternator7/strum" }

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -293,7 +293,7 @@
 //! 7. `EnumDiscriminants`: Given an enum named `MyEnum`, generates another enum called
 //!     `MyEnumDiscriminants` with the same variants, without any data fields. This is useful when you
 //!     wish to determine the variant of an enum from a String, but the variants contain any
-//!     non-`Default` fields. By default, the generated enum has the followign derives:
+//!     non-`Default` fields. By default, the generated enum has the following derives:
 //!     `Clone, Copy, Debug, PartialEq, Eq`. You can add additional derives using the
 //!     `#[strum_discriminants(derive(AdditionalDerive))]` attribute.
 //!
@@ -347,6 +347,29 @@
 //!             vec![MyVariants::Variant0, MyVariants::Variant1],
 //!             MyVariants::iter().collect::<Vec<_>>()
 //!         );
+//!     }
+//!     ```
+//!
+//!     The derived enum also has the following trait implementations:
+//!
+//!     * `impl From<MyEnum> for MyEnumDiscriminants`
+//!     * `impl<'_enum> From<&'_enum MyEnum> for MyEnumDiscriminants`
+//!
+//!     These allow you to get the *Discriminants* enum variant from the original enum:
+//!
+//!     ```rust
+//!     extern crate strum;
+//!     #[macro_use] extern crate strum_macros;
+//!
+//!     #[derive(Debug, EnumDiscriminants)]
+//!     #[strum_discriminants(name(MyVariants))]
+//!     enum MyEnum {
+//!         Variant0(bool),
+//!         Variant1 { a: bool },
+//!     }
+//!
+//!     fn main() {
+//!         assert_eq!(MyVariants::Variant0, MyEnum::Variant0(true).into());
 //!     }
 //!     ```
 //!

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -290,6 +290,66 @@
 //!     }
 //!     ```
 //!
+//! 7. `EnumDiscriminants`: Given an enum named `MyEnum`, generates another enum called
+//!     `MyEnumDiscriminants` with the same variants, without any data fields. This is useful when you
+//!     wish to determine the variant of an enum from a String, but the variants contain any
+//!     non-`Default` fields. By default, the generated enum has the followign derives:
+//!     `Clone, Copy, Debug, PartialEq, Eq`. You can add additional derives using the
+//!     `#[strum_discriminants_derive(AdditionalDerive)]` attribute.
+//!
+//!     Here's an example:
+//!
+//!     ```rust
+//!     # extern crate strum;
+//!     # #[macro_use] extern crate strum_macros;
+//!
+//!     // Bring trait into scope
+//!     use std::str::FromStr;
+//!
+//!     #[derive(Debug)]
+//!     struct NonDefault;
+//!
+//!     #[allow(dead_code)]
+//!     #[derive(Debug, EnumDiscriminants)]
+//!     #[strum_discriminants_derive(EnumString)]
+//!     enum MyEnum {
+//!         Variant0(NonDefault),
+//!         Variant1 { a: NonDefault },
+//!     }
+//!
+//!     fn main() {
+//!         assert_eq!(
+//!             MyEnumDiscriminants::Variant0,
+//!             MyEnumDiscriminants::from_str("Variant0").unwrap()
+//!         );
+//!     }
+//!     ```
+//!
+//!     You can also rename the generated enum using the `#[strum_discriminants_name(OtherName)]`
+//!     attribute:
+//!
+//!     ```rust
+//!     # extern crate strum;
+//!     # #[macro_use] extern crate strum_macros;
+//!     // You need to bring the type into scope to use it!!!
+//!     use strum::IntoEnumIterator;
+//!
+//!     #[allow(dead_code)]
+//!     #[derive(Debug, EnumDiscriminants)]
+//!     #[strum_discriminants_derive(EnumIter)]
+//!     #[strum_discriminants_name(MyVariants)]
+//!     enum MyEnum {
+//!         Variant0(bool),
+//!         Variant1 { a: bool },
+//!     }
+//!
+//!     fn main() {
+//!         assert_eq!(
+//!             vec![MyVariants::Variant0, MyVariants::Variant1],
+//!             MyVariants::iter().collect::<Vec<_>>()
+//!         );
+//!     }
+//!     ```
 //!
 //! # Additional Attributes
 //!

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -14,8 +14,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! strum = "0.9.0"
-//! strum_macros = "0.9.0"
+//! strum = "0.11.0"
+//! strum_macros = "0.11.0"
 //! ```
 //!
 //! And add these lines to the root of your project, either lib.rs or main.rs.
@@ -79,10 +79,10 @@
 //!     # fn main() {}
 //!     ```
 //!
-//!     Note that the implementation of `FromStr` only matches on the name of the variant.
-//!     Strum, where possible, avoids operations that have an unknown runtime cost, and parsing strings
-//!     is potentially an expensive operation. If you do need that behavior, consider the more powerful
-//!     Serde library for your serialization.
+//!     Note that the implementation of `FromStr` by default only matches on the name of the
+//!     variant. There is an option to match on different case conversions through the
+//!     `#[strum(serialize_all = "snake_case")]` type attribute. See the **Additional Attributes**
+//!     Section for more information on using this feature.
 //!
 //! 2. `Display`, `ToString`: both derives print out the given enum variant. This enables you to perform round trip
 //!    style conversions from enum into string and back again for unit style variants. `ToString` and `Display`
@@ -293,8 +293,43 @@
 //!
 //! # Additional Attributes
 //!
-//! Strum supports several custom attributes to modify the generated code. Custom attributes are
-//! applied to a variant by adding #[strum(parameter="value")] to the variant.
+//! Strum supports several custom attributes to modify the generated code. At the enum level, the
+//! `#[strum(serialize_all = "snake_case")]` attribute can be used to change the case used when
+//! serializing to and deserializing from strings:
+//!
+//! ```rust
+//! extern crate strum;
+//! #[macro_use]
+//! extern crate strum_macros;
+//!
+//! #[derive(Debug, Eq, PartialEq, ToString)]
+//! #[strum(serialize_all = "snake_case")]
+//! enum Brightness {
+//!     DarkBlack,
+//!     Dim {
+//!         glow: usize,
+//!     },
+//!     #[strum(serialize = "bright")]
+//!     BrightWhite,
+//! }
+//!
+//! fn main() {
+//!     assert_eq!(
+//!         String::from("dark_black"),
+//!         Brightness::DarkBlack.to_string().as_ref()
+//!     );
+//!     assert_eq!(
+//!         String::from("dim"),
+//!         Brightness::Dim { glow: 0 }.to_string().as_ref()
+//!     );
+//!     assert_eq!(
+//!         String::from("bright"),
+//!         Brightness::BrightWhite.to_string().as_ref()
+//!     );
+//! }
+//! ```
+//!
+//! Custom attributes are applied to a variant by adding `#[strum(parameter="value")]` to the variant.
 //!
 //! - `serialize="..."`: Changes the text that `FromStr()` looks for when parsing a string. This attribute can
 //!    be applied multiple times to an element and the enum variant will be parsed if any of them match.

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -124,14 +124,14 @@
 //!     a borrowed `str` instead of a `String` so you can save an allocation.
 //!
 //! 4. `AsStaticStr`: this is similar to `AsRefStr`, but returns a `'static` reference to a string which is helpful
-//!    in some scenarios. This macro implements `strum::AsStaticRef<str>` which adds a method `.as_static()` that 
+//!    in some scenarios. This macro implements `strum::AsStaticRef<str>` which adds a method `.as_static()` that
 //!    returns a `&'static str`.
-//! 
+//!
 //!    ```rust
 //!    # extern crate strum;
 //!    # #[macro_use] extern crate strum_macros;
 //!    use strum::AsStaticRef;
-//! 
+//!
 //!    #[derive(AsStaticStr)]
 //!    enum State<'a> {
 //!        Initial(&'a str),
@@ -143,14 +143,14 @@
 //!        // The following won't work because the lifetime is incorrect so we can use.as_static() instead.
 //!        // let wrong: &'static str = state.as_ref();
 //!        let right: &'static str = state.as_static();
-//!        println!("{}", right); 
+//!        println!("{}", right);
 //!    }
-//! 
+//!
 //!    fn main() {
 //!        print_state(&"hello world".to_string())
 //!    }
 //!    ```
-//! 
+//!
 //! 4. `EnumIter`: iterate over the variants of an Enum. Any additional data on your variants will be
 //!     set to `Default::default()`. The macro implements `strum::IntoEnumIter` on your enum and
 //!     creates a new type called `YourEnumIter` that implements both `Iterator` and `ExactSizeIterator`.
@@ -402,7 +402,7 @@
 
 /// The ParseError enum is a collection of all the possible reasons
 /// an enum can fail to parse from a string.
-#[derive(Debug,Clone,Copy,Eq,PartialEq,Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum ParseError {
     VariantNotFound,
 }
@@ -543,7 +543,6 @@ pub trait EnumProperty {
         Option::None
     }
 }
-
 
 /// A cheap reference-to-reference conversion. Used to convert a value to a
 /// reference value with `'static` lifetime within generic code.

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -295,7 +295,7 @@
 //!     wish to determine the variant of an enum from a String, but the variants contain any
 //!     non-`Default` fields. By default, the generated enum has the followign derives:
 //!     `Clone, Copy, Debug, PartialEq, Eq`. You can add additional derives using the
-//!     `#[strum_discriminants_derive(AdditionalDerive)]` attribute.
+//!     `#[strum_discriminants(derive(AdditionalDerive))]` attribute.
 //!
 //!     Here's an example:
 //!
@@ -311,7 +311,7 @@
 //!
 //!     #[allow(dead_code)]
 //!     #[derive(Debug, EnumDiscriminants)]
-//!     #[strum_discriminants_derive(EnumString)]
+//!     #[strum_discriminants(derive(EnumString))]
 //!     enum MyEnum {
 //!         Variant0(NonDefault),
 //!         Variant1 { a: NonDefault },
@@ -325,7 +325,7 @@
 //!     }
 //!     ```
 //!
-//!     You can also rename the generated enum using the `#[strum_discriminants_name(OtherName)]`
+//!     You can also rename the generated enum using the `#[strum_discriminants(name(OtherName))]`
 //!     attribute:
 //!
 //!     ```rust
@@ -336,8 +336,7 @@
 //!
 //!     #[allow(dead_code)]
 //!     #[derive(Debug, EnumDiscriminants)]
-//!     #[strum_discriminants_derive(EnumIter)]
-//!     #[strum_discriminants_name(MyVariants)]
+//!     #[strum_discriminants(name(MyVariants), derive(EnumIter))]
 //!     enum MyEnum {
 //!         Variant0(bool),
 //!         Variant1 { a: bool },

--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -20,4 +20,4 @@ name = "strum_macros"
 heck = "0.3"
 proc-macro2 = "0.4"
 quote = "0.6"
-syn = { version = "0.15", features = ["parsing"] }
+syn = { version = "0.15", features = ["parsing", "extra-traits"] }

--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro = true
 name = "strum_macros"
 
 [dependencies]
+heck = "0.3"
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = { version = "0.15", features = ["parsing"] }

--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -19,4 +19,4 @@ name = "strum_macros"
 [dependencies]
 proc-macro2 = "0.4"
 quote = "0.6"
-syn = { version = "0.14", features = ["parsing"] }
+syn = { version = "0.15", features = ["parsing"] }

--- a/strum_macros/src/as_ref_str.rs
+++ b/strum_macros/src/as_ref_str.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use syn;
 
-use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
+use helpers::{extract_attrs, extract_meta, is_disabled, unique_attr};
 
 fn get_arms(ast: &syn::DeriveInput) -> Vec<TokenStream> {
     let name = &ast.ident;

--- a/strum_macros/src/case_style.rs
+++ b/strum_macros/src/case_style.rs
@@ -1,0 +1,34 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CaseStyle {
+    CamelCase,
+    KebabCase,
+    MixedCase,
+    ShoutySnakeCase,
+    SnakeCase,
+    TitleCase,
+}
+
+impl<'s> From<&'s str> for CaseStyle {
+    fn from(text: &'s str) -> CaseStyle {
+        match text {
+            "camel_case" => CaseStyle::CamelCase,
+            "kebab_case" => CaseStyle::KebabCase,
+            "mixed_case" => CaseStyle::MixedCase,
+            "shouty_snake_case" | "shouty_snek_case" => CaseStyle::ShoutySnakeCase,
+            "snake_case" | "snek_case" => CaseStyle::SnakeCase,
+            "title_case" => CaseStyle::TitleCase,
+            _ => panic!(
+                "Unexpected case style for serialize_all: `{}`. Valid values are: `{:?}`",
+                text,
+                [
+                    "camel_case",
+                    "kebab_case",
+                    "mixed_case",
+                    "shouty_snake_case",
+                    "snake_case",
+                    "title_case"
+                ]
+            ),
+        }
+    }
+}

--- a/strum_macros/src/display.rs
+++ b/strum_macros/src/display.rs
@@ -1,7 +1,8 @@
 use proc_macro2::TokenStream;
 use syn;
 
-use helpers::{extract_attrs, extract_meta, is_disabled, unique_attr};
+use case_style::CaseStyle;
+use helpers::{convert_case, extract_attrs, extract_meta, is_disabled, unique_attr};
 
 pub fn display_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
@@ -10,6 +11,10 @@ pub fn display_inner(ast: &syn::DeriveInput) -> TokenStream {
         syn::Data::Enum(ref v) => &v.variants,
         _ => panic!("Display only works on Enums"),
     };
+
+    let type_meta = extract_meta(&ast.attrs);
+    let case_style = unique_attr(&type_meta, "strum", "serialize_all")
+        .map(|style| CaseStyle::from(style.as_ref()));
 
     let mut arms = Vec::new();
     for variant in variants {
@@ -31,7 +36,7 @@ pub fn display_inner(ast: &syn::DeriveInput) -> TokenStream {
             if let Some(n) = attrs.pop() {
                 n
             } else {
-                ident.to_string()
+                convert_case(ident, case_style)
             }
         };
 

--- a/strum_macros/src/display.rs
+++ b/strum_macros/src/display.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use syn;
 
-use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
+use helpers::{extract_attrs, extract_meta, is_disabled, unique_attr};
 
 pub fn display_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;

--- a/strum_macros/src/enum_discriminants.rs
+++ b/strum_macros/src/enum_discriminants.rs
@@ -1,0 +1,47 @@
+use proc_macro2::{Span, TokenStream};
+use syn;
+
+use helpers::{extract_meta, extract_meta_attrs};
+
+pub fn enum_discriminants_inner(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let vis = &ast.vis;
+    let enum_discriminants_name = syn::Ident::new(
+        &format!("{}Discriminants", name.to_string()),
+        Span::call_site(),
+    );
+
+    let variants = match ast.data {
+        syn::Data::Enum(ref v) => &v.variants,
+        _ => panic!("EnumDiscriminants only works on Enums"),
+    };
+
+    let type_meta = extract_meta(&ast.attrs);
+    let discriminant_derives = extract_meta_attrs(&type_meta, "strum_discriminants_derive");
+    let derives = quote! {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, #(#discriminant_derives),*)]
+    };
+
+    let mut discriminants = Vec::new();
+    for variant in variants {
+        let ident = &variant.ident;
+
+        // Don't copy across the "strum" meta attribute.
+        let attrs = variant.attrs.iter().filter(|attr| {
+            attr.interpret_meta().map_or(true, |meta| match meta {
+                syn::Meta::List(ref metalist) => metalist.ident != "strum",
+                _ => true,
+            })
+        });
+
+        discriminants.push(quote!{ #(#attrs)* #ident });
+    }
+
+    quote!{
+        /// Auto-generated discriminant enum variants
+        #derives
+        #vis enum #enum_discriminants_name {
+            #(#discriminants),*
+        }
+    }
+}

--- a/strum_macros/src/enum_discriminants.rs
+++ b/strum_macros/src/enum_discriminants.rs
@@ -1,15 +1,11 @@
 use proc_macro2::{Span, TokenStream};
 use syn;
 
-use helpers::{extract_meta, extract_meta_attrs};
+use helpers::{extract_meta, extract_meta_attrs, unique_meta_attr};
 
 pub fn enum_discriminants_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let vis = &ast.vis;
-    let enum_discriminants_name = syn::Ident::new(
-        &format!("{}Discriminants", name.to_string()),
-        Span::call_site(),
-    );
 
     let variants = match ast.data {
         syn::Data::Enum(ref v) => &v.variants,
@@ -21,6 +17,13 @@ pub fn enum_discriminants_inner(ast: &syn::DeriveInput) -> TokenStream {
     let derives = quote! {
         #[derive(Clone, Copy, Debug, PartialEq, Eq, #(#discriminant_derives),*)]
     };
+
+    let default_name = syn::Ident::new(
+        &format!("{}Discriminants", name.to_string()),
+        Span::call_site(),
+    );
+    let enum_discriminants_name =
+        unique_meta_attr(&type_meta, "strum_discriminants_name").unwrap_or(&default_name);
 
     let mut discriminants = Vec::new();
     for variant in variants {

--- a/strum_macros/src/enum_iter.rs
+++ b/strum_macros/src/enum_iter.rs
@@ -10,8 +10,10 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> TokenStream {
     let vis = &ast.vis;
 
     if gen.lifetimes().count() > 0 {
-        panic!("Enum Iterator isn't supported on Enums with lifetimes. The resulting enums would \
-                 be unbounded.");
+        panic!(
+            "Enum Iterator isn't supported on Enums with lifetimes. The resulting enums would \
+             be unbounded."
+        );
     }
 
     let phantom_data = if gen.type_params().count() > 0 {
@@ -42,7 +44,10 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> TokenStream {
                 quote! { (#(#defaults),*) }
             }
             Named(ref fields) => {
-                let fields = fields.named.iter().map(|field| field.ident.as_ref().unwrap());
+                let fields = fields
+                    .named
+                    .iter()
+                    .map(|field| field.ident.as_ref().unwrap());
                 quote! { {#(#fields: ::std::default::Default::default()),*} }
             }
         };

--- a/strum_macros/src/enum_messages.rs
+++ b/strum_macros/src/enum_messages.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use syn;
 
-use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
+use helpers::{extract_attrs, extract_meta, is_disabled, unique_attr};
 
 pub fn enum_message_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;

--- a/strum_macros/src/enum_properties.rs
+++ b/strum_macros/src/enum_properties.rs
@@ -8,35 +8,40 @@ fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
     use syn::{MetaList, MetaNameValue, NestedMeta};
     meta.iter()
         .filter_map(|meta| match *meta {
-            Meta::List(MetaList { ref ident, ref nested, .. }) => {
+            Meta::List(MetaList {
+                ref ident,
+                ref nested,
+                ..
+            }) => {
                 if ident == "strum" {
                     Some(nested)
                 } else {
                     None
                 }
-            },
+            }
             _ => None,
-        })
-        .flat_map(|prop| prop)
+        }).flat_map(|prop| prop)
         .filter_map(|prop| match *prop {
-            NestedMeta::Meta(Meta::List(MetaList { ref ident, ref nested, .. })) => {
+            NestedMeta::Meta(Meta::List(MetaList {
+                ref ident,
+                ref nested,
+                ..
+            })) => {
                 if ident == "props" {
                     Some(nested)
                 } else {
                     None
                 }
-            },
+            }
             _ => None,
-        })
-        .flat_map(|prop| prop)
+        }).flat_map(|prop| prop)
         // Only look at key value pairs
         .filter_map(|prop| match *prop {
-            NestedMeta::Meta(Meta::NameValue(MetaNameValue { ref ident, ref lit, .. })) => {
-                Some((ident, lit))
-            },
+            NestedMeta::Meta(Meta::NameValue(MetaNameValue {
+                ref ident, ref lit, ..
+            })) => Some((ident, lit)),
             _ => None,
-        })
-        .collect()
+        }).collect()
 }
 
 pub fn enum_properties_inner(ast: &syn::DeriveInput) -> TokenStream {

--- a/strum_macros/src/from_string.rs
+++ b/strum_macros/src/from_string.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use syn;
 
-use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
+use helpers::{extract_attrs, extract_meta, is_disabled, unique_attr};
 
 pub fn from_string_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
@@ -56,12 +56,15 @@ pub fn from_string_inner(ast: &syn::DeriveInput) -> TokenStream {
         let params = match variant.fields {
             Unit => quote!{},
             Unnamed(ref fields) => {
-                let defaults = ::std::iter::repeat(quote!(Default::default()))
-                    .take(fields.unnamed.len());
+                let defaults =
+                    ::std::iter::repeat(quote!(Default::default())).take(fields.unnamed.len());
                 quote! { (#(#defaults),*) }
             }
             Named(ref fields) => {
-                let fields = fields.named.iter().map(|field| field.ident.as_ref().unwrap());
+                let fields = fields
+                    .named
+                    .iter()
+                    .map(|field| field.ident.as_ref().unwrap());
                 quote! { {#(#fields: Default::default()),*} }
             }
         };

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -1,8 +1,8 @@
-
 use syn::{Attribute, Meta};
 
 pub fn extract_meta(attrs: &[Attribute]) -> Vec<Meta> {
-    attrs.iter()
+    attrs
+        .iter()
         .filter_map(|attribute| attribute.interpret_meta())
         .collect()
 }
@@ -18,10 +18,9 @@ pub fn extract_attrs(meta: &[Meta], attr: &str, prop: &str) -> Vec<String> {
                 } else {
                     None
                 }
-            },
+            }
             _ => None,
-        })
-        .flat_map(|nested| nested)
+        }).flat_map(|nested| nested)
         // Get all the inner elements as long as they start with ser.
         .filter_map(|meta| match *meta {
             NestedMeta::Meta(Meta::NameValue(MetaNameValue {
@@ -34,10 +33,9 @@ pub fn extract_attrs(meta: &[Meta], attr: &str, prop: &str) -> Vec<String> {
                 } else {
                     None
                 }
-            },
+            }
             _ => None,
-        })
-        .collect()
+        }).collect()
 }
 
 pub fn unique_attr(attrs: &[Meta], attr: &str, prop: &str) -> Option<String> {

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -60,6 +60,11 @@ where
     filter_meta_lists(metas, move |metalist| metalist.ident == attr)
 }
 
+/// Returns the `MetaList` that matches the given name from the list of `Meta`s, or `None`.
+///
+/// # Panics
+///
+/// Panics if more than one `Meta` exists with the name.
 pub fn unique_meta_list<'meta, MetaIt>(metas: MetaIt, attr: &'meta str) -> Option<&'meta MetaList>
 where
     MetaIt: Iterator<Item = &'meta Meta>,
@@ -72,6 +77,7 @@ where
     curr.pop()
 }
 
+/// Returns an iterator of the `Meta`s from the given `MetaList`.
 pub fn extract_list_metas<'meta>(metalist: &'meta MetaList) -> impl Iterator<Item = &'meta Meta> {
     use syn::NestedMeta;
     metalist.nested.iter().filter_map(|nested| match *nested {
@@ -80,16 +86,7 @@ pub fn extract_list_metas<'meta>(metalist: &'meta MetaList) -> impl Iterator<Ite
     })
 }
 
-/// Returns the `Ident`s from the `Meta::List`s that match the given `attr` name.
-///
-/// For example, `extract_meta_idents(something_metas, "Something")` returns `Abc`, `Def`, and `Ghi` for
-/// the following declaration.
-///
-/// ```rust,ignore
-/// #[derive(Debug)]
-/// #[strum(Something(Abc, Def), Something(Ghi))]
-/// struct MyStruct {}
-/// ```
+/// Returns the `Ident` of the `Meta::Word`, or `None`.
 pub fn get_meta_ident<'meta>(meta: &'meta Meta) -> Option<&'meta Ident> {
     match *meta {
         Meta::Word(ref ident) => Some(ident),

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -10,6 +10,27 @@ pub fn extract_meta(attrs: &[Attribute]) -> Vec<Meta> {
         .collect()
 }
 
+pub fn extract_meta_attrs<'meta>(meta: &'meta [Meta], attr: &str) -> Vec<&'meta Ident> {
+    use syn::NestedMeta;
+    meta.iter()
+        // Get all the attributes with our tag on them.
+        .filter_map(|meta| match *meta {
+            Meta::List(ref metalist) => {
+                if metalist.ident == attr {
+                    Some(&metalist.nested)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }).flat_map(|nested| nested)
+        // Get all the inner elements as long as they start with ser.
+        .filter_map(|meta| match *meta {
+            NestedMeta::Meta(Meta::Word(ref ident)) => Some(ident),
+            _ => None,
+        }).collect()
+}
+
 pub fn extract_attrs(meta: &[Meta], attr: &str, prop: &str) -> Vec<String> {
     use syn::{Lit, MetaNameValue, NestedMeta};
     meta.iter()

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -31,6 +31,15 @@ pub fn extract_meta_attrs<'meta>(meta: &'meta [Meta], attr: &str) -> Vec<&'meta 
         }).collect()
 }
 
+pub fn unique_meta_attr<'meta>(attrs: &'meta [Meta], attr: &str) -> Option<&'meta Ident> {
+    let mut curr = extract_meta_attrs(attrs, attr);
+    if curr.len() > 1 {
+        panic!("More than one `{}` attribute found on type", attr);
+    }
+
+    curr.pop()
+}
+
 pub fn extract_attrs(meta: &[Meta], attr: &str, prop: &str) -> Vec<String> {
     use syn::{Lit, MetaNameValue, NestedMeta};
     meta.iter()

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -1,4 +1,7 @@
-use syn::{Attribute, Meta};
+use heck::{CamelCase, KebabCase, MixedCase, ShoutySnakeCase, SnakeCase, TitleCase};
+use syn::{Attribute, Ident, Meta};
+
+use case_style::CaseStyle;
 
 pub fn extract_meta(attrs: &[Attribute]) -> Vec<Meta> {
     attrs
@@ -53,5 +56,21 @@ pub fn is_disabled(attrs: &[Meta]) -> bool {
         0 => false,
         1 => v[0] == "true",
         _ => panic!("Can't have multiple values for 'disabled'"),
+    }
+}
+
+pub fn convert_case(ident: &Ident, case_style: Option<CaseStyle>) -> String {
+    let ident_string = ident.to_string();
+    if let Some(case_style) = case_style {
+        match case_style {
+            CaseStyle::CamelCase => ident_string.to_camel_case(),
+            CaseStyle::KebabCase => ident_string.to_kebab_case(),
+            CaseStyle::MixedCase => ident_string.to_mixed_case(),
+            CaseStyle::ShoutySnakeCase => ident_string.to_shouty_snake_case(),
+            CaseStyle::SnakeCase => ident_string.to_snake_case(),
+            CaseStyle::TitleCase => ident_string.to_title_case(),
+        }
+    } else {
+        ident_string
     }
 }

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![recursion_limit = "128"]
 
+extern crate heck;
 extern crate syn;
 #[macro_use]
 extern crate quote;
@@ -16,6 +17,7 @@ extern crate proc_macro;
 extern crate proc_macro2;
 
 mod as_ref_str;
+mod case_style;
 mod display;
 mod enum_iter;
 mod enum_messages;

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -117,7 +117,7 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 
 #[proc_macro_derive(
     EnumDiscriminants,
-    attributes(strum, strum_discriminants_derive)
+    attributes(strum, strum_discriminants_derive, strum_discriminants_name)
 )]
 pub fn enum_discriminants(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -10,6 +10,7 @@
 #![recursion_limit = "128"]
 
 extern crate heck;
+#[macro_use]
 extern crate syn;
 #[macro_use]
 extern crate quote;

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -19,6 +19,7 @@ extern crate proc_macro2;
 mod as_ref_str;
 mod case_style;
 mod display;
+mod enum_discriminants;
 mod enum_iter;
 mod enum_messages;
 mod enum_properties;
@@ -110,6 +111,18 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
     let ast = syn::parse(input).unwrap();
 
     let toks = enum_properties::enum_properties_inner(&ast);
+    debug_print_generated(&ast, &toks);
+    toks.into()
+}
+
+#[proc_macro_derive(
+    EnumDiscriminants,
+    attributes(strum, strum_discriminants_derive)
+)]
+pub fn enum_discriminants(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = syn::parse(input).unwrap();
+
+    let toks = enum_discriminants::enum_discriminants_inner(&ast);
     debug_print_generated(&ast, &toks);
     toks.into()
 }

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -115,10 +115,7 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
     toks.into()
 }
 
-#[proc_macro_derive(
-    EnumDiscriminants,
-    attributes(strum, strum_discriminants_derive, strum_discriminants_name)
-)]
+#[proc_macro_derive(EnumDiscriminants, attributes(strum, strum_discriminants))]
 pub fn enum_discriminants(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! The documentation for this crate is found in the `strum` crate.
 
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 
 extern crate syn;
 #[macro_use]
@@ -15,17 +15,17 @@ extern crate quote;
 extern crate proc_macro;
 extern crate proc_macro2;
 
-mod helpers;
 mod as_ref_str;
 mod display;
-mod to_string;
-mod from_string;
 mod enum_iter;
 mod enum_messages;
 mod enum_properties;
+mod from_string;
+mod helpers;
+mod to_string;
 
-use std::env;
 use proc_macro2::TokenStream;
+use std::env;
 
 fn debug_print_generated(ast: &syn::DeriveInput, toks: &TokenStream) {
     let debug = env::var("STRUM_DEBUG");
@@ -40,7 +40,7 @@ fn debug_print_generated(ast: &syn::DeriveInput, toks: &TokenStream) {
     }
 }
 
-#[proc_macro_derive(EnumString,attributes(strum))]
+#[proc_macro_derive(EnumString, attributes(strum))]
 pub fn from_string(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
@@ -49,7 +49,7 @@ pub fn from_string(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     toks.into()
 }
 
-#[proc_macro_derive(AsRefStr,attributes(strum))]
+#[proc_macro_derive(AsRefStr, attributes(strum))]
 pub fn as_ref_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
@@ -58,7 +58,7 @@ pub fn as_ref_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     toks.into()
 }
 
-#[proc_macro_derive(AsStaticStr,attributes(strum))]
+#[proc_macro_derive(AsStaticStr, attributes(strum))]
 pub fn as_static_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
@@ -67,7 +67,7 @@ pub fn as_static_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
     toks.into()
 }
 
-#[proc_macro_derive(ToString,attributes(strum))]
+#[proc_macro_derive(ToString, attributes(strum))]
 pub fn to_string(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
@@ -76,7 +76,7 @@ pub fn to_string(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     toks.into()
 }
 
-#[proc_macro_derive(Display,attributes(strum))]
+#[proc_macro_derive(Display, attributes(strum))]
 pub fn display(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
@@ -85,7 +85,7 @@ pub fn display(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     toks.into()
 }
 
-#[proc_macro_derive(EnumIter,attributes(strum))]
+#[proc_macro_derive(EnumIter, attributes(strum))]
 pub fn enum_iter(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
@@ -94,7 +94,7 @@ pub fn enum_iter(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     toks.into()
 }
 
-#[proc_macro_derive(EnumMessage,attributes(strum))]
+#[proc_macro_derive(EnumMessage, attributes(strum))]
 pub fn enum_messages(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
@@ -103,7 +103,7 @@ pub fn enum_messages(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
     toks.into()
 }
 
-#[proc_macro_derive(EnumProperty,attributes(strum))]
+#[proc_macro_derive(EnumProperty, attributes(strum))]
 pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 

--- a/strum_macros/src/to_string.rs
+++ b/strum_macros/src/to_string.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use syn;
 
-use helpers::{unique_attr, extract_attrs, extract_meta, is_disabled};
+use helpers::{extract_attrs, extract_meta, is_disabled, unique_attr};
 
 pub fn to_string_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;

--- a/strum_macros/src/to_string.rs
+++ b/strum_macros/src/to_string.rs
@@ -1,7 +1,8 @@
 use proc_macro2::TokenStream;
 use syn;
 
-use helpers::{extract_attrs, extract_meta, is_disabled, unique_attr};
+use case_style::CaseStyle;
+use helpers::{convert_case, extract_attrs, extract_meta, is_disabled, unique_attr};
 
 pub fn to_string_inner(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
@@ -10,6 +11,10 @@ pub fn to_string_inner(ast: &syn::DeriveInput) -> TokenStream {
         syn::Data::Enum(ref v) => &v.variants,
         _ => panic!("ToString only works on Enums"),
     };
+
+    let type_meta = extract_meta(&ast.attrs);
+    let case_style = unique_attr(&type_meta, "strum", "serialize_all")
+        .map(|style| CaseStyle::from(style.as_ref()));
 
     let mut arms = Vec::new();
     for variant in variants {
@@ -31,7 +36,7 @@ pub fn to_string_inner(ast: &syn::DeriveInput) -> TokenStream {
             if let Some(n) = attrs.pop() {
                 n
             } else {
-                ident.to_string()
+                convert_case(ident, case_style)
             }
         };
 

--- a/strum_tests/Cargo.toml
+++ b/strum_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strum_tests"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Peter Glotfelty <peglotfe@microsoft.com>"]
 
 [dependencies]

--- a/strum_tests/src/main.rs
+++ b/strum_tests/src/main.rs
@@ -3,15 +3,15 @@ extern crate strum;
 extern crate strum_macros;
 
 #[allow(dead_code)]
-#[derive(Debug,Eq,PartialEq,EnumString,ToString)]
+#[derive(Debug, Eq, PartialEq, EnumString, ToString)]
 enum Color {
-    #[strum(to_string="RedRed")]
+    #[strum(to_string = "RedRed")]
     Red,
-    #[strum(serialize="b", to_string="blue")]
+    #[strum(serialize = "b", to_string = "blue")]
     Blue { hue: usize },
-    #[strum(serialize="y",serialize="yellow")]
+    #[strum(serialize = "y", serialize = "yellow")]
     Yellow,
-    #[strum(disabled="true")]
+    #[strum(disabled = "true")]
     Green(String),
 }
 

--- a/strum_tests/tests/as_ref_no_strum.rs
+++ b/strum_tests/tests/as_ref_no_strum.rs
@@ -1,15 +1,15 @@
 #[macro_use]
 extern crate strum_macros;
 
-#[derive(Debug,Eq,PartialEq,AsRefStr)]
+#[derive(Debug, Eq, PartialEq, AsRefStr)]
 enum Color {
-    #[strum(to_string="RedRed")]
+    #[strum(to_string = "RedRed")]
     Red,
-    #[strum(serialize="b", to_string="blue")]
+    #[strum(serialize = "b", to_string = "blue")]
     Blue { hue: usize },
-    #[strum(serialize="y", serialize="yellow")]
+    #[strum(serialize = "y", serialize = "yellow")]
     Yellow,
-    #[strum(default="true")]
+    #[strum(default = "true")]
     Green(String),
 }
 

--- a/strum_tests/tests/as_ref_str.rs
+++ b/strum_tests/tests/as_ref_str.rs
@@ -5,15 +5,15 @@ extern crate strum_macros;
 use std::str::FromStr;
 use strum::AsStaticRef;
 
-#[derive(Debug,Eq,PartialEq,EnumString,AsRefStr,AsStaticStr)]
+#[derive(Debug, Eq, PartialEq, EnumString, AsRefStr, AsStaticStr)]
 enum Color {
-    #[strum(to_string="RedRed")]
+    #[strum(to_string = "RedRed")]
     Red,
-    #[strum(serialize="b", to_string="blue")]
+    #[strum(serialize = "b", to_string = "blue")]
     Blue { hue: usize },
-    #[strum(serialize="y", serialize="yellow")]
+    #[strum(serialize = "y", serialize = "yellow")]
     Yellow,
-    #[strum(default="true")]
+    #[strum(default = "true")]
     Green(String),
 }
 

--- a/strum_tests/tests/display.rs
+++ b/strum_tests/tests/display.rs
@@ -28,3 +28,30 @@ fn to_yellow_string() {
 fn to_red_string() {
     assert_eq!(String::from("RedRed"), format!("{}", Color::Red));
 }
+
+#[derive(Display, Debug, Eq, PartialEq)]
+#[strum(serialize_all = "snake_case")]
+enum Brightness {
+    DarkBlack,
+    Dim {
+        glow: usize,
+    },
+    #[strum(serialize = "bright")]
+    BrightWhite,
+}
+
+#[test]
+fn brightness_to_string() {
+    assert_eq!(
+        String::from("dark_black"),
+        Brightness::DarkBlack.to_string().as_ref()
+    );
+    assert_eq!(
+        String::from("dim"),
+        Brightness::Dim { glow: 0 }.to_string().as_ref()
+    );
+    assert_eq!(
+        String::from("bright"),
+        Brightness::BrightWhite.to_string().as_ref()
+    );
+}

--- a/strum_tests/tests/display.rs
+++ b/strum_tests/tests/display.rs
@@ -2,15 +2,15 @@ extern crate strum;
 #[macro_use]
 extern crate strum_macros;
 
-#[derive(Debug,Eq,PartialEq, EnumString, Display)]
+#[derive(Debug, Eq, PartialEq, EnumString, Display)]
 enum Color {
-    #[strum(to_string="RedRed")]
+    #[strum(to_string = "RedRed")]
     Red,
-    #[strum(serialize="b", to_string="blue")]
+    #[strum(serialize = "b", to_string = "blue")]
     Blue { hue: usize },
-    #[strum(serialize="y", serialize="yellow")]
+    #[strum(serialize = "y", serialize = "yellow")]
     Yellow,
-    #[strum(default="true")]
+    #[strum(default = "true")]
     Green(String),
 }
 

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -163,3 +163,24 @@ fn from_ref_test() {
     assert_eq!(EnumIntoDiscriminants::A, (&EnumInto::A(true)).into());
     assert_eq!(EnumIntoDiscriminants::B, (&EnumInto::B(1)).into());
 }
+
+#[derive(Debug)]
+struct Rara;
+
+#[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
+#[strum_discriminants(name(EnumIntoComplexVars),)]
+enum EnumIntoComplex<'a, T: 'a> {
+    A(&'a T),
+}
+
+#[test]
+fn from_test_complex() {
+    let rara = Rara;
+    assert_eq!(EnumIntoComplexVars::A, EnumIntoComplex::A(&rara).into());
+}
+
+#[test]
+fn from_ref_test_complex() {
+    let rara = Rara;
+    assert_eq!(EnumIntoComplexVars::A, (&EnumIntoComplex::A(&rara)).into());
+}

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -84,3 +84,20 @@ enum WithDefault {
 fn with_default_test() {
     assert!(WithDefaultDiscriminants::A != WithDefaultDiscriminants::B);
 }
+
+#[allow(dead_code)]
+#[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
+#[strum_discriminants_derive(EnumIter)]
+#[strum_discriminants_name(EnumBoo)]
+enum Renamed {
+    Variant0(bool),
+    Variant1(i32),
+}
+
+#[test]
+fn renamed_test() {
+    let discriminants = EnumBoo::iter().collect::<Vec<_>>();
+    let expected = vec![EnumBoo::Variant0, EnumBoo::Variant1];
+
+    assert_eq!(expected, discriminants);
+}

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -1,0 +1,86 @@
+extern crate strum;
+#[macro_use]
+extern crate strum_macros;
+
+use strum::IntoEnumIterator;
+
+#[allow(dead_code)]
+#[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
+#[strum_discriminants_derive(EnumIter)]
+enum Simple {
+    Variant0,
+    Variant1,
+}
+
+#[test]
+fn simple_test() {
+    let discriminants = SimpleDiscriminants::iter().collect::<Vec<_>>();
+    let expected = vec![SimpleDiscriminants::Variant0, SimpleDiscriminants::Variant1];
+
+    assert_eq!(expected, discriminants);
+}
+
+#[derive(Debug)]
+struct NonDefault;
+
+#[allow(dead_code)]
+#[derive(Debug, EnumDiscriminants)]
+#[strum_discriminants_derive(EnumIter)]
+enum WithFields {
+    Variant0(NonDefault),
+    Variant1 { a: NonDefault },
+}
+
+#[test]
+fn fields_test() {
+    let discriminants = WithFieldsDiscriminants::iter().collect::<Vec<_>>();
+    let expected = vec![
+        WithFieldsDiscriminants::Variant0,
+        WithFieldsDiscriminants::Variant1,
+    ];
+
+    assert_eq!(expected, discriminants);
+}
+
+trait Foo {}
+trait Bar {}
+
+#[allow(dead_code)]
+#[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
+#[strum_discriminants_derive(EnumIter)]
+enum Complicated<U: Foo, V: Bar> {
+    /// With Docs
+    A(U),
+    B {
+        v: V,
+    },
+    C,
+}
+
+#[test]
+fn complicated_test() {
+    let discriminants = ComplicatedDiscriminants::iter().collect::<Vec<_>>();
+    let expected = vec![
+        ComplicatedDiscriminants::A,
+        ComplicatedDiscriminants::B,
+        ComplicatedDiscriminants::C,
+    ];
+
+    assert_eq!(expected, discriminants);
+}
+
+// This test exists to ensure that we do not copy across the `#[strum(default = "true")]` meta
+// attribute. If we do without deriving any `strum` derivations on the generated discriminant enum,
+// Rust will generate a compiler error saying it doesn't understand the `strum` attribute.
+#[allow(dead_code)]
+#[derive(Debug, EnumDiscriminants)]
+enum WithDefault {
+    #[strum(default = "true")]
+    A(String),
+    B,
+}
+
+#[test]
+fn with_default_test() {
+    assert!(WithDefaultDiscriminants::A != WithDefaultDiscriminants::B);
+}

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -157,3 +157,9 @@ fn from_test() {
     assert_eq!(EnumIntoDiscriminants::A, EnumInto::A(true).into());
     assert_eq!(EnumIntoDiscriminants::B, EnumInto::B(1).into());
 }
+
+#[test]
+fn from_ref_test() {
+    assert_eq!(EnumIntoDiscriminants::A, (&EnumInto::A(true)).into());
+    assert_eq!(EnumIntoDiscriminants::B, (&EnumInto::B(1)).into());
+}

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -145,3 +145,15 @@ fn arbitrary_attributes_pass_through() {
         PassThroughBoo::from_str("dark_black").unwrap()
     );
 }
+
+#[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
+enum EnumInto {
+    A(bool),
+    B(i32),
+}
+
+#[test]
+fn from_test() {
+    assert_eq!(EnumIntoDiscriminants::A, EnumInto::A(true).into());
+    assert_eq!(EnumIntoDiscriminants::B, EnumInto::B(1).into());
+}

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -100,3 +100,21 @@ fn renamed_test() {
 
     assert_eq!(expected, discriminants);
 }
+
+#[allow(dead_code)]
+#[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
+#[strum_discriminants(name(SplitAttributesBoo), derive(Display))]
+#[strum_discriminants(derive(EnumIter))]
+enum SplitAttributes {
+    Variant0(bool),
+    Variant1(i32),
+}
+
+#[test]
+fn split_attributes_test() {
+    let discriminants = SplitAttributesBoo::iter().collect::<Vec<_>>();
+    let expected = vec![SplitAttributesBoo::Variant0, SplitAttributesBoo::Variant1];
+
+    assert_eq!(expected, discriminants);
+    assert_eq!("Variant0", format!("{}", SplitAttributesBoo::Variant0));
+}

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -6,7 +6,7 @@ use strum::IntoEnumIterator;
 
 #[allow(dead_code)]
 #[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
-#[strum_discriminants_derive(EnumIter)]
+#[strum_discriminants(derive(EnumIter))]
 enum Simple {
     Variant0,
     Variant1,
@@ -25,7 +25,7 @@ struct NonDefault;
 
 #[allow(dead_code)]
 #[derive(Debug, EnumDiscriminants)]
-#[strum_discriminants_derive(EnumIter)]
+#[strum_discriminants(derive(EnumIter))]
 enum WithFields {
     Variant0(NonDefault),
     Variant1 { a: NonDefault },
@@ -47,7 +47,7 @@ trait Bar {}
 
 #[allow(dead_code)]
 #[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
-#[strum_discriminants_derive(EnumIter)]
+#[strum_discriminants(derive(EnumIter))]
 enum Complicated<U: Foo, V: Bar> {
     /// With Docs
     A(U),
@@ -87,8 +87,7 @@ fn with_default_test() {
 
 #[allow(dead_code)]
 #[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
-#[strum_discriminants_derive(EnumIter)]
-#[strum_discriminants_name(EnumBoo)]
+#[strum_discriminants(name(EnumBoo), derive(EnumIter))]
 enum Renamed {
     Variant0(bool),
     Variant1(i32),

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -118,3 +118,30 @@ fn split_attributes_test() {
     assert_eq!(expected, discriminants);
     assert_eq!("Variant0", format!("{}", SplitAttributesBoo::Variant0));
 }
+
+#[allow(dead_code)]
+#[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
+#[strum_discriminants(
+    name(PassThroughBoo),
+    derive(Display, EnumIter, EnumString),
+    strum(serialize_all = "snake_case"),
+)]
+enum PassThrough {
+    DarkBlack(bool),
+    BrightWhite(i32),
+}
+
+#[test]
+fn arbitrary_attributes_pass_through() {
+    use std::str::FromStr;
+
+    let discriminants = PassThroughBoo::iter().collect::<Vec<_>>();
+    let expected = vec![PassThroughBoo::DarkBlack, PassThroughBoo::BrightWhite];
+
+    assert_eq!(expected, discriminants);
+    assert_eq!("dark_black", PassThroughBoo::DarkBlack.to_string());
+    assert_eq!(
+        PassThroughBoo::DarkBlack,
+        PassThroughBoo::from_str("dark_black").unwrap()
+    );
+}

--- a/strum_tests/tests/enum_iter.rs
+++ b/strum_tests/tests/enum_iter.rs
@@ -4,7 +4,7 @@ extern crate strum_macros;
 
 use strum::IntoEnumIterator;
 
-#[derive(Debug,Eq,PartialEq,EnumIter)]
+#[derive(Debug, Eq, PartialEq, EnumIter)]
 enum Week {
     Sunday,
     Monday,
@@ -18,18 +18,20 @@ enum Week {
 #[test]
 fn simple_test() {
     let results = Week::iter().collect::<Vec<_>>();
-    let expected = vec![Week::Sunday,
-                        Week::Monday,
-                        Week::Tuesday,
-                        Week::Wednesday,
-                        Week::Thursday,
-                        Week::Friday,
-                        Week::Saturday];
+    let expected = vec![
+        Week::Sunday,
+        Week::Monday,
+        Week::Tuesday,
+        Week::Wednesday,
+        Week::Thursday,
+        Week::Friday,
+        Week::Saturday,
+    ];
 
     assert_eq!(expected, results);
 }
 
-#[derive(Debug,Eq,PartialEq,EnumIter)]
+#[derive(Debug, Eq, PartialEq, EnumIter)]
 enum Complicated<U: Default, V: Default> {
     A(U),
     B { v: V },
@@ -39,19 +41,21 @@ enum Complicated<U: Default, V: Default> {
 #[test]
 fn complicated_test() {
     let results = Complicated::iter().collect::<Vec<_>>();
-    let expected = vec![Complicated::A(0),
-                        Complicated::B { v: String::new() },
-                        Complicated::C];
+    let expected = vec![
+        Complicated::A(0),
+        Complicated::B { v: String::new() },
+        Complicated::C,
+    ];
 
     assert_eq!(expected, results);
 }
 
 #[test]
 fn len_test() {
-    let mut i = Complicated::<(),()>::iter();
+    let mut i = Complicated::<(), ()>::iter();
     assert_eq!(3, i.len());
     i.next();
-    
+
     assert_eq!(2, i.len());
     i.next();
 
@@ -82,15 +86,17 @@ fn clone_test() {
 #[test]
 fn cycle_test() {
     let results = Week::iter().cycle().take(10).collect::<Vec<_>>();
-    let expected = vec![Week::Sunday,
-                        Week::Monday,
-                        Week::Tuesday,
-                        Week::Wednesday,
-                        Week::Thursday,
-                        Week::Friday,
-                        Week::Saturday,
-                        Week::Sunday,
-                        Week::Monday,
-                        Week::Tuesday];
+    let expected = vec![
+        Week::Sunday,
+        Week::Monday,
+        Week::Tuesday,
+        Week::Wednesday,
+        Week::Thursday,
+        Week::Friday,
+        Week::Saturday,
+        Week::Sunday,
+        Week::Monday,
+        Week::Tuesday,
+    ];
     assert_eq!(expected, results);
 }

--- a/strum_tests/tests/enum_message.rs
+++ b/strum_tests/tests/enum_message.rs
@@ -4,17 +4,17 @@ extern crate strum_macros;
 
 use strum::EnumMessage;
 
-#[derive(Debug,Eq,PartialEq,EnumMessage)]
+#[derive(Debug, Eq, PartialEq, EnumMessage)]
 enum Pets {
-    #[strum(message="I'm a dog")]
+    #[strum(message = "I'm a dog")]
     Dog,
-    #[strum(message="I'm a cat")]
-    #[strum(detailed_message="I'm a very exquisite striped cat")]
+    #[strum(message = "I'm a cat")]
+    #[strum(detailed_message = "I'm a very exquisite striped cat")]
     Cat,
-    #[strum(detailed_message="My fish is named Charles McFish")]
+    #[strum(detailed_message = "My fish is named Charles McFish")]
     Fish,
     Bird,
-    #[strum(disabled="true")]
+    #[strum(disabled = "true")]
     Hamster,
 }
 
@@ -27,15 +27,19 @@ fn simple_message() {
 #[test]
 fn detailed_message() {
     assert_eq!("I'm a cat", (Pets::Cat).get_message().unwrap());
-    assert_eq!("I'm a very exquisite striped cat",
-               (Pets::Cat).get_detailed_message().unwrap());
+    assert_eq!(
+        "I'm a very exquisite striped cat",
+        (Pets::Cat).get_detailed_message().unwrap()
+    );
 }
 
 #[test]
 fn only_detailed_message() {
     assert_eq!(None, (Pets::Fish).get_message());
-    assert_eq!("My fish is named Charles McFish",
-               (Pets::Fish).get_detailed_message().unwrap());
+    assert_eq!(
+        "My fish is named Charles McFish",
+        (Pets::Fish).get_detailed_message().unwrap()
+    );
 }
 
 #[test]

--- a/strum_tests/tests/enum_props.rs
+++ b/strum_tests/tests/enum_props.rs
@@ -6,7 +6,7 @@ use strum::EnumProperty;
 
 #[derive(Debug, EnumProperty)]
 enum Test {
-    #[strum(props(key="value"))]
+    #[strum(props(key = "value"))]
     A,
     B,
 }

--- a/strum_tests/tests/from_str.rs
+++ b/strum_tests/tests/from_str.rs
@@ -4,15 +4,17 @@ extern crate strum_macros;
 
 use std::str::FromStr;
 
-#[derive(Debug,Eq,PartialEq,EnumString)]
+#[derive(Debug, Eq, PartialEq, EnumString)]
 enum Color {
     Red,
-    Blue { hue: usize },
-    #[strum(serialize="y",serialize="yellow")]
+    Blue {
+        hue: usize,
+    },
+    #[strum(serialize = "y", serialize = "yellow")]
     Yellow,
-    #[strum(default="true")]
+    #[strum(default = "true")]
     Green(String),
-    #[strum(to_string="purp")]
+    #[strum(to_string = "purp")]
     Purple,
 }
 
@@ -39,11 +41,13 @@ fn color_to_string() {
 
 #[test]
 fn color_default() {
-    assert_eq!(Color::Green(String::from("not found")),
-               Color::from_str("not found").unwrap());
+    assert_eq!(
+        Color::Green(String::from("not found")),
+        Color::from_str("not found").unwrap()
+    );
 }
 
-#[derive(Debug,Eq,PartialEq,EnumString)]
+#[derive(Debug, Eq, PartialEq, EnumString)]
 enum Week {
     Sunday,
     Monday,
@@ -56,8 +60,10 @@ enum Week {
 
 #[test]
 fn week_not_found() {
-    assert_eq!(Result::Err(::strum::ParseError::VariantNotFound),
-               Week::from_str("Humpday"));
+    assert_eq!(
+        Result::Err(::strum::ParseError::VariantNotFound),
+        Week::from_str("Humpday")
+    );
 }
 
 #[test]
@@ -71,7 +77,7 @@ fn week_found() {
     assert_eq!(Result::Ok(Week::Saturday), Week::from_str("Saturday"));
 }
 
-#[derive(Debug,Eq,PartialEq,EnumString)]
+#[derive(Debug, Eq, PartialEq, EnumString)]
 enum Lifetime<'a> {
     Life(&'a str),
     None,
@@ -82,7 +88,7 @@ fn lifetime_test() {
     assert_eq!(Lifetime::Life(""), Lifetime::from_str("Life").unwrap());
 }
 
-#[derive(Debug,Eq,PartialEq,EnumString)]
+#[derive(Debug, Eq, PartialEq, EnumString)]
 enum Generic<T: Default> {
     Gen(T),
     None,

--- a/strum_tests/tests/from_str.rs
+++ b/strum_tests/tests/from_str.rs
@@ -48,6 +48,33 @@ fn color_default() {
 }
 
 #[derive(Debug, Eq, PartialEq, EnumString)]
+#[strum(serialize_all = "snake_case")]
+enum Brightness {
+    DarkBlack,
+    Dim {
+        glow: usize,
+    },
+    #[strum(serialize = "Bright")]
+    BrightWhite,
+}
+
+#[test]
+fn brightness_serialize_all() {
+    assert_eq!(
+        Brightness::DarkBlack,
+        Brightness::from_str("dark_black").unwrap()
+    );
+    assert_eq!(
+        Brightness::Dim { glow: 0 },
+        Brightness::from_str("dim").unwrap()
+    );
+    assert_eq!(
+        Brightness::BrightWhite,
+        Brightness::from_str("Bright").unwrap()
+    );
+}
+
+#[derive(Debug, Eq, PartialEq, EnumString)]
 enum Week {
     Sunday,
     Monday,

--- a/strum_tests/tests/to_string.rs
+++ b/strum_tests/tests/to_string.rs
@@ -38,3 +38,30 @@ fn to_red_string() {
         Color::from_str((Color::Red).to_string().as_ref()).unwrap()
     );
 }
+
+#[derive(Debug, Eq, PartialEq, ToString)]
+#[strum(serialize_all = "snake_case")]
+enum Brightness {
+    DarkBlack,
+    Dim {
+        glow: usize,
+    },
+    #[strum(serialize = "bright")]
+    BrightWhite,
+}
+
+#[test]
+fn brightness_to_string() {
+    assert_eq!(
+        String::from("dark_black"),
+        Brightness::DarkBlack.to_string().as_ref()
+    );
+    assert_eq!(
+        String::from("dim"),
+        Brightness::Dim { glow: 0 }.to_string().as_ref()
+    );
+    assert_eq!(
+        String::from("bright"),
+        Brightness::BrightWhite.to_string().as_ref()
+    );
+}

--- a/strum_tests/tests/to_string.rs
+++ b/strum_tests/tests/to_string.rs
@@ -5,22 +5,24 @@ extern crate strum_macros;
 use std::str::FromStr;
 use std::string::ToString;
 
-#[derive(Debug,Eq,PartialEq, EnumString, ToString)]
+#[derive(Debug, Eq, PartialEq, EnumString, ToString)]
 enum Color {
-    #[strum(to_string="RedRed")]
+    #[strum(to_string = "RedRed")]
     Red,
-    #[strum(serialize="b", to_string="blue")]
+    #[strum(serialize = "b", to_string = "blue")]
     Blue { hue: usize },
-    #[strum(serialize="y", serialize="yellow")]
+    #[strum(serialize = "y", serialize = "yellow")]
     Yellow,
-    #[strum(default="true")]
+    #[strum(default = "true")]
     Green(String),
 }
 
 #[test]
 fn to_blue_string() {
-    assert_eq!(String::from("blue"),
-               (Color::Blue { hue: 0 }).to_string().as_ref());
+    assert_eq!(
+        String::from("blue"),
+        (Color::Blue { hue: 0 }).to_string().as_ref()
+    );
 }
 
 #[test]
@@ -31,6 +33,8 @@ fn to_yellow_string() {
 #[test]
 fn to_red_string() {
     assert_eq!(String::from("RedRed"), (Color::Red).to_string());
-    assert_eq!(Color::Red,
-               Color::from_str((Color::Red).to_string().as_ref()).unwrap());
+    assert_eq!(
+        Color::Red,
+        Color::from_str((Color::Red).to_string().as_ref()).unwrap()
+    );
 }


### PR DESCRIPTION
Implemented #33.
~~there's an error that I can't work out, see commit `429040a`, uncommenting that code causes the compiler to panic (it doesn't find the `strum` attribute, even though it's clearly defined).~~ Fixed it.

This branch was branched off #32, so it's a bit noisy from that.