### PR TITLE
Add `EnumVariantNames`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Strum has implemented the following macros:
 | [Display](#Display) | Converts enum variants to strings |
 | [AsRefStr](#AsRefStr) | Converts enum variants to `&'static str` |
 | [IntoStaticStr](#IntoStaticStr) | Implements `From<MyEnum> for &'static str` on an enum |
-| [EnumVariantNames](#EnumVariantNames) | Adds a `variant` method returning an array of discriminant names |
+| [EnumVariantNames](#EnumVariantNames) | Adds a `variants` method returning an array of discriminant names |
 | [EnumIter](#EnumIter) | Creates a new type that iterates of the variants of an enum. |
 | [EnumProperty](#EnumProperty) | Add custom properties to enum variants. |
 | [EnumMessage](#EnumMessage) | Add a verbose message to an enum variant. |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Strum has implemented the following macros:
 | [Display](#Display) | Converts enum variants to strings |
 | [AsRefStr](#AsRefStr) | Converts enum variants to `&'static str` |
 | [IntoStaticStr](#IntoStaticStr) | Implements `From<MyEnum> for &'static str` on an enum |
+| [EnumVariantNames](#EnumVariantNames) | Adds a `variant` method returning an array of discriminant names |
 | [EnumIter](#EnumIter) | Creates a new type that iterates of the variants of an enum. |
 | [EnumProperty](#EnumProperty) | Add custom properties to enum variants. |
 | [EnumMessage](#EnumMessage) | Add a verbose message to an enum variant. |
@@ -188,6 +189,48 @@ fn print_state<'a>(s:&'a str) {
 
 fn main() {
     print_state(&"hello world".to_string())
+}
+```
+
+## EnumVariantNames
+
+Adds an `impl` block for the `enum` that adds a static `variants()` method that returns an array of `&'static str` that are the discriminant names.
+This will respect the `serialize_all` attribute on the `enum` (like `#[strum(serialize_all = "snake_case")]`, see **Additional Attributes** below).
+
+**Note:** This is compatible with the format [clap](https://docs.rs/clap/2) expects for `enums`, meaning this works:
+
+```rust
+use strum::{EnumString, EnumVariantNames};
+
+#[derive(EnumString, EnumVariantNames)]
+#[strum(serialize_all = "kebab_case")]
+enum Color {
+    Red,
+    Blue,
+    Yellow,
+    RebeccaPurple,
+}
+
+fn main() {
+    let args = clap::App::new("app")
+        .arg(Arg::with_name("color")
+            .long("color")
+            .possible_values(&Color::variants())
+            .case_insensitive(true))
+        .get_matches();
+
+    // ...
+}
+```
+
+or with [structopt](https://docs.rs/structopt/0.2) (assuming the same definition of `Color` as above):
+
+```rust
+#[derive(Debug, StructOpt)]
+struct Cli {
+    /// The main color
+    #[structopt(long = "color", default_value = "Color::Blue", raw(possible_values = "&Color::variants()"))]
+    color: Color,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ enum Color {
 }
 
 fn main() {
+    // This is what you get:
+    assert_eq!(
+        &Color::variants(),
+        &["red", "blue", "yellow", "rebecca-purple"]
+    );
+    
+    // Use it with clap like this:
     let args = clap::App::new("app")
         .arg(Arg::with_name("color")
             .long("color")
@@ -223,7 +230,7 @@ fn main() {
 }
 ```
 
-or with [structopt](https://docs.rs/structopt/0.2) (assuming the same definition of `Color` as above):
+This also works with [structopt](https://docs.rs/structopt/0.2) (assuming the same definition of `Color` as above):
 
 ```rust
 #[derive(Debug, StructOpt)]

--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -25,6 +25,7 @@ syn = { version = "0.15", features = ["parsing", "extra-traits"] }
 [features]
 verbose-enumstring-name = []
 verbose-asrefstr-name = []
+verbose-variant-names = []
 verbose-asstaticstr-name = []
 verbose-intostaticstr-name = []
 verbose-tostring-name = []

--- a/strum_macros/src/enum_variant_names.rs
+++ b/strum_macros/src/enum_variant_names.rs
@@ -24,6 +24,7 @@ pub fn enum_variant_names_inner(ast: &syn::DeriveInput) -> TokenStream {
 
     quote! {
         impl #name {
+            /// Return a slice containing the names of the variants of this enum
             #[allow(dead_code)]
             pub fn variants() -> &'static [&'static str] {
                 &[

--- a/strum_macros/src/enum_variant_names.rs
+++ b/strum_macros/src/enum_variant_names.rs
@@ -1,0 +1,36 @@
+use proc_macro2::TokenStream;
+use syn;
+
+use case_style::CaseStyle;
+use helpers::{convert_case, extract_meta, unique_attr};
+
+pub fn enum_variant_names_inner(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let variants = match ast.data {
+        syn::Data::Enum(ref v) => &v.variants,
+        _ => panic!("EnumVariantNames only works on Enums"),
+    };
+
+    // Derives for the generated enum
+    let type_meta = extract_meta(&ast.attrs);
+    let case_style = unique_attr(&type_meta, "strum", "serialize_all")
+        .map(|style| CaseStyle::from(style.as_ref()));
+
+    let names = variants
+        .iter()
+        .map(|v| convert_case(&v.ident, case_style))
+        .collect::<Vec<_>>();
+    let len = names.len();
+
+    quote! {
+        impl #name {
+            #[allow(dead_code)]
+            pub fn variants() -> [&'static str; #len] {
+                [
+                    #(#names),*
+                ]
+            }
+        }
+    }
+}

--- a/strum_macros/src/enum_variant_names.rs
+++ b/strum_macros/src/enum_variant_names.rs
@@ -21,13 +21,12 @@ pub fn enum_variant_names_inner(ast: &syn::DeriveInput) -> TokenStream {
         .iter()
         .map(|v| convert_case(&v.ident, case_style))
         .collect::<Vec<_>>();
-    let len = names.len();
 
     quote! {
         impl #name {
             #[allow(dead_code)]
-            pub fn variants() -> [&'static str; #len] {
-                [
+            pub fn variants() -> &'static [&'static str] {
+                &[
                     #(#names),*
                 ]
             }

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -22,6 +22,7 @@ mod case_style;
 mod display;
 mod enum_count;
 mod enum_discriminants;
+mod enum_variant_names;
 mod enum_iter;
 mod enum_messages;
 mod enum_properties;
@@ -61,6 +62,16 @@ pub fn as_ref_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
     let toks = as_ref_str::as_ref_str_inner(&ast);
+    debug_print_generated(&ast, &toks);
+    toks.into()
+}
+
+#[cfg_attr(not(feature = "verbose-variant-names"), proc_macro_derive(EnumVariantNames, attributes(strum)))]
+#[cfg_attr(feature = "verbose-variant-names", proc_macro_derive(StrumEnumVariantNames, attributes(strum)))]
+pub fn variant_names(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = syn::parse(input).unwrap();
+
+    let toks = enum_variant_names::enum_variant_names_inner(&ast);
     debug_print_generated(&ast, &toks);
     toks.into()
 }

--- a/strum_tests/Cargo.toml
+++ b/strum_tests/Cargo.toml
@@ -6,3 +6,5 @@ authors = ["Peter Glotfelty <peglotfe@microsoft.com>"]
 [dependencies]
 strum = { path = "../strum" }
 strum_macros = { path = "../strum_macros", features = [] }
+clap = "2.33.0"
+structopt = "0.2.18"

--- a/strum_tests/tests/enum_variant_names.rs
+++ b/strum_tests/tests/enum_variant_names.rs
@@ -1,0 +1,51 @@
+#[macro_use]
+extern crate strum_macros;
+
+#[test]
+fn simple() {
+    #[allow(dead_code)]
+    #[derive(EnumVariantNames)]
+    enum Color {
+        Red,
+        Blue,
+        Yellow,
+    }
+
+    assert_eq!(&Color::variants(), &["Red", "Blue", "Yellow"]);
+}
+
+#[test]
+fn plain_kebab() {
+    #[allow(dead_code)]
+    #[derive(EnumVariantNames)]
+    #[strum(serialize_all = "kebab_case")]
+    enum Color {
+        Red,
+        Blue,
+        Yellow,
+        RebeccaPurple,
+    }
+
+    assert_eq!(
+        &Color::variants(),
+        &["red", "blue", "yellow", "rebecca-purple"]
+    );
+}
+
+#[test]
+fn non_plain_camel() {
+    #[allow(dead_code)]
+    #[derive(EnumVariantNames)]
+    #[strum(serialize_all = "kebab_case")]
+    enum Color {
+        DeepPink,
+        GreenYellow,
+        CornflowerBlue,
+        Other { r: u8, g: u8, b: u8 },
+    }
+
+    assert_eq!(
+        &Color::variants(),
+        &["deep-pink", "green-yellow", "cornflower-blue", "other"]
+    );
+}

--- a/strum_tests/tests/enum_variant_names.rs
+++ b/strum_tests/tests/enum_variant_names.rs
@@ -1,5 +1,8 @@
 #[macro_use]
 extern crate strum_macros;
+#[macro_use]
+extern crate structopt;
+extern crate strum;
 
 #[test]
 fn simple() {
@@ -48,4 +51,40 @@ fn non_plain_camel() {
         &Color::variants(),
         &["deep-pink", "green-yellow", "cornflower-blue", "other"]
     );
+}
+
+#[test]
+fn clap_and_structopt() {
+    #[derive(Debug, EnumString, EnumVariantNames)]
+    #[strum(serialize_all = "kebab_case")]
+    enum Color {
+        Red,
+        Blue,
+        Yellow,
+        RebeccaPurple,
+    }
+
+    assert_eq!(
+        &Color::variants(),
+        &["red", "blue", "yellow", "rebecca-purple"]
+    );
+
+    let _clap_example = clap::App::new("app").arg(
+        clap::Arg::with_name("color")
+            .long("color")
+            .possible_values(Color::variants())
+            .case_insensitive(true),
+    );
+
+    #[derive(Debug, StructOpt)]
+    #[allow(unused)]
+    struct StructOptExample {
+        /// The main color
+        #[structopt(
+            long = "color",
+            default_value = "Color::Blue",
+            raw(possible_values = "Color::variants()")
+        )]
+        color: Color,
+    }
 }


### PR DESCRIPTION
This derive adds a static `variants()` methods yielding the names of
the enum variants. This happens to be exactly what clap [wants][1], and
is the last puzzle piece to use strum with clap/structopt.

[1]: https://docs.rs/clap/2.33.0/clap/macro.arg_enum.html