### PR TITLE
Add feature gate `derive` for re-exporting proc macros to `strum`.

### DIFF
--- a/strum/Cargo.toml
+++ b/strum/Cargo.toml
@@ -12,8 +12,14 @@ documentation = "https://docs.rs/strum"
 homepage = "https://github.com/Peternator7/strum"
 readme = "../README.md"
 
+[dependencies]
+strum_macros = { path = "../strum_macros", optional = true, version = "0.15.0" }
+
 [dev-dependencies]
 strum_macros = { path = "../strum_macros", version = "0.15.0" }
 
 [badges]
 travis-ci = { repository = "Peternator7/strum" }
+
+[features]
+derive = ["strum_macros"]

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -206,3 +206,12 @@ where
 pub trait EnumCount {
     fn count() -> usize;
 }
+
+#[cfg(feature = "derive")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate strum_macros;
+
+#[cfg(feature = "derive")]
+#[doc(hidden)]
+pub use strum_macros::*;

--- a/strum_tests/Cargo.toml
+++ b/strum_tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.15.0"
 authors = ["Peter Glotfelty <peglotfe@microsoft.com>"]
 
 [dependencies]
-strum = { path = "../strum" }
+strum = { path = "../strum", features = ["derive"] }
 strum_macros = { path = "../strum_macros", features = [] }
 clap = "2.33.0"
 structopt = "0.2.18"

--- a/strum_tests/src/lib.rs
+++ b/strum_tests/src/lib.rs
@@ -1,6 +1,8 @@
+#![allow(unused_imports)]
 extern crate strum;
 #[macro_use]
 extern crate strum_macros;
+use strum::*;
 
 #[allow(dead_code)]
 #[derive(Debug, Eq, PartialEq, EnumString, ToString, EnumCount, EnumDiscriminants)]

--- a/strum_tests/tests/enum_message.rs
+++ b/strum_tests/tests/enum_message.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 extern crate strum;
 #[macro_use]
 extern crate strum_macros;

--- a/strum_tests/tests/enum_props.rs
+++ b/strum_tests/tests/enum_props.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 extern crate strum;
 #[macro_use]
 extern crate strum_macros;


### PR DESCRIPTION
This is a shortcut to use proc macros without manually specifying `strum_macros` as a dependency, just as `serde` and many other packages do. So we can simply use `use strum::*;` (or `#[macro_use] extern crate strum;` for rustc prior to 1.31.0) to `derive`.

It is already tested to be compatible with rustc 1.26.0

Maybe more documentation is needed?

