### PR TITLE
Bump `proc-macro2`, `quote`, and `syn` to 1.0

### DIFF
--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -18,9 +18,9 @@ name = "strum_macros"
 
 [dependencies]
 heck = "0.3"
-proc-macro2 = "0.4"
-quote = "0.6"
-syn = { version = "0.15", features = ["parsing", "extra-traits"] }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["parsing", "extra-traits"] }
 
 [features]
 verbose-enumstring-name = []

--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -20,7 +20,7 @@ name = "strum_macros"
 heck = "0.3"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["parsing", "extra-traits"] }
+syn = { version = "1.0.3", features = ["parsing", "extra-traits"] }
 
 [features]
 verbose-enumstring-name = []

--- a/strum_macros/src/enum_properties.rs
+++ b/strum_macros/src/enum_properties.rs
@@ -2,18 +2,18 @@ use proc_macro2::TokenStream;
 use syn;
 use syn::Meta;
 
-use helpers::{extract_meta, is_disabled};
+use helpers::{eq_path_str, extract_meta, is_disabled};
 
 fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
     use syn::{MetaList, MetaNameValue, NestedMeta};
     meta.iter()
         .filter_map(|meta| match *meta {
             Meta::List(MetaList {
-                ref ident,
+                ref path,
                 ref nested,
                 ..
             }) => {
-                if ident == "strum" {
+                if eq_path_str(path, "strum") {
                     Some(nested)
                 } else {
                     None
@@ -24,11 +24,11 @@ fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
         .flat_map(|prop| prop)
         .filter_map(|prop| match *prop {
             NestedMeta::Meta(Meta::List(MetaList {
-                ref ident,
+                ref path,
                 ref nested,
                 ..
             })) => {
-                if ident == "props" {
+                if eq_path_str(path, "props") {
                     Some(nested)
                 } else {
                     None
@@ -40,8 +40,8 @@ fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
         // Only look at key value pairs
         .filter_map(|prop| match *prop {
             NestedMeta::Meta(Meta::NameValue(MetaNameValue {
-                ref ident, ref lit, ..
-            })) => Some((ident, lit)),
+                ref path, ref lit, ..
+            })) => Some((&path.segments[0].ident, lit)),
             _ => None,
         })
         .collect()

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -188,5 +188,5 @@ fn test_convert_case() {
 /// Note that the given string should be a single path segment.
 /// In other words, it should not be multi-segment path like `a::b::c`.
 pub fn eq_path_str(path: &Path, s: &str) -> bool {
-    (path.segments.len() == 1) && (path.segments[0].ident == s)
+    path.get_ident().map_or(false, |ident| ident == s)
 }


### PR DESCRIPTION
* Add `helpers::eq_path_str` to compare a path and a string.
* Use `syn::Attribute::parse_meta()` instead of `interpret_meta()`.
* Extract ident from path, if necessary.
    + Some of `syn` types now have `path` member instead of `ident`.

Closes #63.