### PR TITLE
Refactoring (mainly fixing clippy lint warnings)

### DIFF
--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -59,7 +59,7 @@ impl std::fmt::Display for ParseError {
         // We could use our macro here, but this way we don't take a dependency on the
         // macros crate.
         match self {
-            &ParseError::VariantNotFound => write!(f, "Matching variant not found"),
+            ParseError::VariantNotFound => write!(f, "Matching variant not found"),
         }
     }
 }
@@ -67,7 +67,7 @@ impl std::fmt::Display for ParseError {
 impl std::error::Error for ParseError {
     fn description(&self) -> &str {
         match self {
-            &ParseError::VariantNotFound => {
+            ParseError::VariantNotFound => {
                 "Unable to find a variant of the given enum matching the string given. Matching \
                  can be extended with the Serialize attribute and is case sensitive."
             }

--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -18,9 +18,9 @@ name = "strum_macros"
 
 [dependencies]
 heck = "0.3"
-proc-macro2 = "0.4"
-quote = "0.6"
-syn = { version = "0.15", features = ["parsing", "extra-traits"] }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["parsing", "extra-traits"] }
 
 [features]
 verbose-enumstring-name = []

--- a/strum_macros/src/enum_discriminants.rs
+++ b/strum_macros/src/enum_discriminants.rs
@@ -2,8 +2,7 @@ use proc_macro2::{Span, TokenStream};
 use syn;
 
 use helpers::{
-    eq_path_str, extract_list_metas, extract_meta, filter_metas, get_meta_ident, get_meta_list,
-    unique_meta_list,
+    eq_path_str, extract_list_metas, extract_meta, get_meta_ident, get_meta_list, unique_meta_list,
 };
 
 pub fn enum_discriminants_inner(ast: &syn::DeriveInput) -> TokenStream {
@@ -42,9 +41,11 @@ pub fn enum_discriminants_inner(ast: &syn::DeriveInput) -> TokenStream {
         .unwrap_or(&default_name);
 
     // Pass through all other attributes
-    let pass_though_attributes =
-        filter_metas(discriminant_attrs.iter().map(|&m| m), |meta| match meta {
-            syn::Meta::List(ref metalist) => {
+    let pass_though_attributes = discriminant_attrs
+        .iter()
+        .map(|&m| m)
+        .filter(|meta| match meta {
+            syn::Meta::List(metalist) => {
                 !eq_path_str(&metalist.path, "derive") && !eq_path_str(&metalist.path, "name")
             }
             _ => true,

--- a/strum_macros/src/enum_discriminants.rs
+++ b/strum_macros/src/enum_discriminants.rs
@@ -61,7 +61,7 @@ pub fn enum_discriminants_inner(ast: &syn::DeriveInput) -> TokenStream {
         // Don't copy across the "strum" meta attribute.
         let attrs = variant.attrs.iter().filter(|attr| {
             attr.parse_meta().ok().map_or(true, |meta| match meta {
-                syn::Meta::List(ref metalist) => !eq_path_str(&metalist.path, "strum"),
+                syn::Meta::List(metalist) => !eq_path_str(&metalist.path, "strum"),
                 _ => true,
             })
         });

--- a/strum_macros/src/enum_discriminants.rs
+++ b/strum_macros/src/enum_discriminants.rs
@@ -20,7 +20,7 @@ pub fn enum_discriminants_inner(ast: &syn::DeriveInput) -> TokenStream {
         .flat_map(|meta| extract_list_metas(meta).collect::<Vec<_>>())
         .collect::<Vec<&syn::Meta>>();
 
-    let derives = get_meta_list(discriminant_attrs.iter().map(|&m| m), "derive")
+    let derives = get_meta_list(discriminant_attrs.iter().copied(), "derive")
         .flat_map(extract_list_metas)
         .filter_map(get_meta_ident)
         .collect::<Vec<_>>();
@@ -35,7 +35,7 @@ pub fn enum_discriminants_inner(ast: &syn::DeriveInput) -> TokenStream {
         Span::call_site(),
     );
 
-    let discriminants_name = unique_meta_list(discriminant_attrs.iter().map(|&m| m), "name")
+    let discriminants_name = unique_meta_list(discriminant_attrs.iter().copied(), "name")
         .map(extract_list_metas)
         .and_then(|metas| metas.filter_map(get_meta_ident).next())
         .unwrap_or(&default_name);
@@ -43,7 +43,7 @@ pub fn enum_discriminants_inner(ast: &syn::DeriveInput) -> TokenStream {
     // Pass through all other attributes
     let pass_though_attributes = discriminant_attrs
         .iter()
-        .map(|&m| m)
+        .copied()
         .filter(|meta| match meta {
             syn::Meta::List(metalist) => {
                 !eq_path_str(&metalist.path, "derive") && !eq_path_str(&metalist.path, "name")

--- a/strum_macros/src/enum_messages.rs
+++ b/strum_macros/src/enum_messages.rs
@@ -31,7 +31,7 @@ pub fn enum_message_inner(ast: &syn::DeriveInput) -> TokenStream {
         // You can't disable getting the serializations.
         {
             let mut serialization_variants = extract_attrs(&meta, "strum", "serialize");
-            if serialization_variants.len() == 0 {
+            if serialization_variants.is_empty() {
                 serialization_variants.push(ident.to_string());
             }
 

--- a/strum_macros/src/enum_properties.rs
+++ b/strum_macros/src/enum_properties.rs
@@ -2,18 +2,18 @@ use proc_macro2::TokenStream;
 use syn;
 use syn::Meta;
 
-use helpers::{extract_meta, is_disabled};
+use helpers::{eq_path_str, extract_meta, is_disabled};
 
 fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
     use syn::{MetaList, MetaNameValue, NestedMeta};
     meta.iter()
         .filter_map(|meta| match *meta {
             Meta::List(MetaList {
-                ref ident,
+                ref path,
                 ref nested,
                 ..
             }) => {
-                if ident == "strum" {
+                if eq_path_str(path, "strum") {
                     Some(nested)
                 } else {
                     None
@@ -24,11 +24,11 @@ fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
         .flat_map(|prop| prop)
         .filter_map(|prop| match *prop {
             NestedMeta::Meta(Meta::List(MetaList {
-                ref ident,
+                ref path,
                 ref nested,
                 ..
             })) => {
-                if ident == "props" {
+                if eq_path_str(path, "props") {
                     Some(nested)
                 } else {
                     None
@@ -40,8 +40,8 @@ fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
         // Only look at key value pairs
         .filter_map(|prop| match *prop {
             NestedMeta::Meta(Meta::NameValue(MetaNameValue {
-                ref ident, ref lit, ..
-            })) => Some((ident, lit)),
+                ref path, ref lit, ..
+            })) => Some((&path.segments[0].ident, lit)),
             _ => None,
         })
         .collect()

--- a/strum_macros/src/enum_properties.rs
+++ b/strum_macros/src/enum_properties.rs
@@ -7,12 +7,8 @@ use helpers::{eq_path_str, extract_meta, is_disabled};
 fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
     use syn::{MetaList, MetaNameValue, NestedMeta};
     meta.iter()
-        .filter_map(|meta| match *meta {
-            Meta::List(MetaList {
-                ref path,
-                ref nested,
-                ..
-            }) => {
+        .filter_map(|meta| match meta {
+            Meta::List(MetaList { path, nested, .. }) => {
                 if eq_path_str(path, "strum") {
                     Some(nested)
                 } else {
@@ -22,12 +18,8 @@ fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
             _ => None,
         })
         .flat_map(|prop| prop)
-        .filter_map(|prop| match *prop {
-            NestedMeta::Meta(Meta::List(MetaList {
-                ref path,
-                ref nested,
-                ..
-            })) => {
+        .filter_map(|prop| match prop {
+            NestedMeta::Meta(Meta::List(MetaList { path, nested, .. })) => {
                 if eq_path_str(path, "props") {
                     Some(nested)
                 } else {
@@ -38,10 +30,10 @@ fn extract_properties(meta: &[Meta]) -> Vec<(&syn::Ident, &syn::Lit)> {
         })
         .flat_map(|prop| prop)
         // Only look at key value pairs
-        .filter_map(|prop| match *prop {
-            NestedMeta::Meta(Meta::NameValue(MetaNameValue {
-                ref path, ref lit, ..
-            })) => Some((&path.segments[0].ident, lit)),
+        .filter_map(|prop| match prop {
+            NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit, .. })) => {
+                Some((&path.segments[0].ident, lit))
+            }
             _ => None,
         })
         .collect()
@@ -78,7 +70,7 @@ pub fn enum_properties_inner(ast: &syn::DeriveInput) -> TokenStream {
             use syn::Lit::*;
             let key = key.to_string();
             match value {
-                Str(ref s, ..) => {
+                Str(s, ..) => {
                     string_arms.push(quote! { #key => ::std::option::Option::Some( #s )})
                 }
                 Bool(b) => bool_arms.push(quote! { #key => ::std::option::Option::Some( #b )}),

--- a/strum_macros/src/from_string.rs
+++ b/strum_macros/src/from_string.rs
@@ -54,7 +54,7 @@ pub fn from_string_inner(ast: &syn::DeriveInput) -> TokenStream {
         }
 
         // If we don't have any custom variants, add the default serialized name.
-        if attrs.len() == 0 {
+        if attrs.is_empty() {
             attrs.push(convert_case(ident, case_style));
         }
 

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -70,7 +70,7 @@ where
 }
 
 /// Returns an iterator of the `Meta`s from the given `MetaList`.
-pub fn extract_list_metas<'meta>(metalist: &'meta MetaList) -> impl Iterator<Item = &'meta Meta> {
+pub fn extract_list_metas(metalist: &MetaList) -> impl Iterator<Item = &Meta> {
     use syn::NestedMeta;
     metalist.nested.iter().filter_map(|nested| match *nested {
         NestedMeta::Meta(ref meta) => Some(meta),
@@ -79,7 +79,7 @@ pub fn extract_list_metas<'meta>(metalist: &'meta MetaList) -> impl Iterator<Ite
 }
 
 /// Returns the `Ident` of the `Meta::Word`, or `None`.
-pub fn get_meta_ident<'meta>(meta: &'meta Meta) -> Option<&'meta Ident> {
+pub fn get_meta_ident(meta: &Meta) -> Option<&Ident> {
     match *meta {
         Meta::Path(ref path) => Some(&path.segments[0].ident),
         _ => None,

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -61,7 +61,7 @@ pub fn unique_meta_list<'meta, MetaIt>(metas: MetaIt, attr: &'meta str) -> Optio
 where
     MetaIt: Iterator<Item = &'meta Meta>,
 {
-    let mut curr = get_meta_list(metas.into_iter(), attr).collect::<Vec<_>>();
+    let mut curr = get_meta_list(metas, attr).collect::<Vec<_>>();
     if curr.len() > 1 {
         panic!("More than one `{}` attribute found on type", attr);
     }

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -42,12 +42,12 @@ where
 /// #[strum_discriminant(name(MyEnumVariants))]
 /// enum MyEnum { A }
 /// ```
-pub fn get_meta_list<'meta, MetaIt>(
+pub fn get_meta_list<'iter, 'meta: 'iter, MetaIt>(
     metas: MetaIt,
-    attr: &'meta str,
-) -> impl Iterator<Item = &'meta MetaList>
+    attr: &'iter str,
+) -> impl Iterator<Item = &'meta MetaList> + 'iter
 where
-    MetaIt: Iterator<Item = &'meta Meta>,
+    MetaIt: Iterator<Item = &'meta Meta> + 'iter,
 {
     filter_meta_lists(metas, move |metalist| eq_path_str(&metalist.path, attr))
 }
@@ -57,7 +57,7 @@ where
 /// # Panics
 ///
 /// Panics if more than one `Meta` exists with the name.
-pub fn unique_meta_list<'meta, MetaIt>(metas: MetaIt, attr: &'meta str) -> Option<&'meta MetaList>
+pub fn unique_meta_list<'meta, MetaIt>(metas: MetaIt, attr: &'_ str) -> Option<&'meta MetaList>
 where
     MetaIt: Iterator<Item = &'meta Meta>,
 {

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -19,7 +19,7 @@ where
     F: Fn(&MetaList) -> bool,
 {
     metas.filter_map(move |meta| match meta {
-        Meta::List(ref metalist) => {
+        Meta::List(metalist) => {
             if filter(metalist) {
                 Some(metalist)
             } else {
@@ -72,16 +72,16 @@ where
 /// Returns an iterator of the `Meta`s from the given `MetaList`.
 pub fn extract_list_metas(metalist: &MetaList) -> impl Iterator<Item = &Meta> {
     use syn::NestedMeta;
-    metalist.nested.iter().filter_map(|nested| match *nested {
-        NestedMeta::Meta(ref meta) => Some(meta),
+    metalist.nested.iter().filter_map(|nested| match nested {
+        NestedMeta::Meta(meta) => Some(meta),
         _ => None,
     })
 }
 
 /// Returns the `Ident` of the `Meta::Word`, or `None`.
 pub fn get_meta_ident(meta: &Meta) -> Option<&Ident> {
-    match *meta {
-        Meta::Path(ref path) => Some(&path.segments[0].ident),
+    match meta {
+        Meta::Path(path) => Some(&path.segments[0].ident),
         _ => None,
     }
 }
@@ -90,8 +90,8 @@ pub fn extract_attrs(meta: &[Meta], attr: &str, prop: &str) -> Vec<String> {
     use syn::{Lit, MetaNameValue, NestedMeta};
     meta.iter()
         // Get all the attributes with our tag on them.
-        .filter_map(|meta| match *meta {
-            Meta::List(ref metalist) => {
+        .filter_map(|meta| match meta {
+            Meta::List(metalist) => {
                 if eq_path_str(&metalist.path, attr) {
                     Some(&metalist.nested)
                 } else {
@@ -102,10 +102,10 @@ pub fn extract_attrs(meta: &[Meta], attr: &str, prop: &str) -> Vec<String> {
         })
         .flat_map(|nested| nested)
         // Get all the inner elements as long as they start with ser.
-        .filter_map(|meta| match *meta {
+        .filter_map(|meta| match meta {
             NestedMeta::Meta(Meta::NameValue(MetaNameValue {
-                ref path,
-                lit: Lit::Str(ref s),
+                path,
+                lit: Lit::Str(s),
                 ..
             })) => {
                 if eq_path_str(path, prop) {

--- a/strum_macros/src/helpers.rs
+++ b/strum_macros/src/helpers.rs
@@ -10,14 +10,6 @@ pub fn extract_meta(attrs: &[Attribute]) -> Vec<Meta> {
         .collect()
 }
 
-pub fn filter_metas<'meta, MetaIt, F>(metas: MetaIt, filter: F) -> impl Iterator<Item = &'meta Meta>
-where
-    MetaIt: Iterator<Item = &'meta Meta>,
-    F: Fn(&Meta) -> bool,
-{
-    metas.filter_map(move |meta| if filter(meta) { Some(meta) } else { None })
-}
-
 pub fn filter_meta_lists<'meta, MetaIt, F>(
     metas: MetaIt,
     filter: F,


### PR DESCRIPTION
NOTE: This branch is based on #65.

Fixing clippy lint warnings, and some tiny changes which does not change strum's behavior.

I'm wondering whether the commit <https://github.com/Peternator7/strum/commit/ff4f6087e4a4f7a5fd0834871a7d928d13721866> should be included in this pull request.
This uses `Iterator::copied()` which is stabilized since Rust 1.36, but I'm not sure what version of Rust strum should support.
When strum use `syn`-1.0, it bumps minimal Rust requirement version to Rust 1.31 or later.
Can it be Rust 1.36?