### PR TITLE
Fix inaccurate case_style

### DIFF
--- a/strum_macros/src/case_style.rs
+++ b/strum_macros/src/case_style.rs
@@ -16,23 +16,25 @@ impl<'s> From<&'s str> for CaseStyle {
     fn from(text: &'s str) -> CaseStyle {
         match text {
             "lowercase" => CaseStyle::LowerCase,
-            "camel_case" | "PascalCase" => CaseStyle::PascalCase,
+            "pascal_case" | "PascalCase" => CaseStyle::PascalCase,
             "kebab_case" | "kebab-case" => CaseStyle::KebabCase,
             "mixed_case" => CaseStyle::MixedCase,
             "shouty_snake_case" | "shouty_snek_case" | "SCREAMING_SNAKE_CASE" => {
                 CaseStyle::ShoutySnakeCase
             }
             "snake_case" | "snek_case" => CaseStyle::SnakeCase,
-            "title_case" => CaseStyle::TitleCase,
+            "title_case" | "Title Case" => CaseStyle::TitleCase,
             "UPPERCASE" => CaseStyle::UpperCase,
-            "camelCase" => CaseStyle::CamelCase,
+            "camel_case" | "camelCase" => CaseStyle::CamelCase,
             "SCREAMING-KEBAB-CASE" => CaseStyle::ScreamingKebabCase,
             _ => panic!(
                 "Unexpected case style for serialize_all: `{}`. Valid values are: `{:?}`",
                 text,
                 [
+                    "lowercase",
                     "camel_case",
                     "kebab_case",
+                    "pascal_case",
                     "mixed_case",
                     "shouty_snake_case",
                     "snake_case",


### PR DESCRIPTION
especially on `#[strum(serialize_all = camel_case)]`