### PR TITLE
Const enum variants names

### DIFF
--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -223,11 +223,6 @@ pub trait EnumCount {
 pub trait VariantNames {
     /// Names of the variants of this enum
     const VARIANTS: &'static [&'static str];
-
-    /// Return a slice containing the names of the variants of this enum
-    fn variants() -> &'static [&'static str] {
-        Self::VARIANTS
-    }
 }
 
 #[cfg(feature = "derive")]

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -221,7 +221,13 @@ pub trait EnumCount {
 /// A trait for retrieving the names of each variant in Enum. This trait can
 /// be autoderived by `strum_macros`.
 pub trait VariantNames {
-    fn variants() -> &'static [&'static str];
+    /// Names of the variants of this enum
+    const VARIANTS: &'static [&'static str];
+
+    /// Return a slice containing the names of the variants of this enum
+    fn variants() -> &'static [&'static str] {
+        Self::VARIANTS
+    }
 }
 
 #[cfg(feature = "derive")]

--- a/strum_macros/src/macros/enum_variant_names.rs
+++ b/strum_macros/src/macros/enum_variant_names.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{TokenStream, Span};
+use proc_macro2::TokenStream;
 use syn;
 
 use crate::helpers::case_style::CaseStyle;
@@ -23,11 +23,6 @@ pub fn enum_variant_names_inner(ast: &syn::DeriveInput) -> TokenStream {
         .map(|v| v.ident.convert_case(case_style))
         .collect::<Vec<_>>();
 
-    let note = syn::Lit::Str(syn::LitStr::new(
-        &format!("Use `{name}::VARIANTS` instead", name = name.to_string()),
-        Span::call_site(),
-    ));
-
     quote! {
         impl #name {
             /// Names of the variants of this enum
@@ -36,8 +31,7 @@ pub fn enum_variant_names_inner(ast: &syn::DeriveInput) -> TokenStream {
 
             /// Return a slice containing the names of the variants of this enum
             #[allow(dead_code)]
-            #[deprecated = #note]
-            pub const fn variants() -> &'static [&'static str] {
+            pub fn variants() -> &'static [&'static str] {
                 Self::VARIANTS
             }
         }

--- a/strum_macros/src/macros/enum_variant_names.rs
+++ b/strum_macros/src/macros/enum_variant_names.rs
@@ -1,4 +1,4 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{TokenStream, Span};
 use syn;
 
 use crate::helpers::case_style::CaseStyle;
@@ -23,14 +23,22 @@ pub fn enum_variant_names_inner(ast: &syn::DeriveInput) -> TokenStream {
         .map(|v| v.ident.convert_case(case_style))
         .collect::<Vec<_>>();
 
+    let note = syn::Lit::Str(syn::LitStr::new(
+        &format!("Use {name}::VARIANTS instead", name = name.to_string()),
+        Span::call_site(),
+    ));
+
     quote! {
         impl #name {
+            /// Names of the variants of this enum
+            #[allow(dead_code)]
+            pub const VARIANTS: &'static [&'static str] = &[ #(#names),* ];
+
             /// Return a slice containing the names of the variants of this enum
             #[allow(dead_code)]
-            pub fn variants() -> &'static [&'static str] {
-                &[
-                    #(#names),*
-                ]
+            #[deprecated = #note]
+            pub const fn variants() -> &'static [&'static str] {
+                Self::VARIANTS
             }
         }
     }

--- a/strum_macros/src/macros/enum_variant_names.rs
+++ b/strum_macros/src/macros/enum_variant_names.rs
@@ -24,7 +24,7 @@ pub fn enum_variant_names_inner(ast: &syn::DeriveInput) -> TokenStream {
         .collect::<Vec<_>>();
 
     let note = syn::Lit::Str(syn::LitStr::new(
-        &format!("Use {name}::VARIANTS instead", name = name.to_string()),
+        &format!("Use `{name}::VARIANTS` instead", name = name.to_string()),
         Span::call_site(),
     ));
 

--- a/strum_macros/src/macros/enum_variant_names.rs
+++ b/strum_macros/src/macros/enum_variant_names.rs
@@ -25,18 +25,8 @@ pub fn enum_variant_names_inner(ast: &syn::DeriveInput) -> TokenStream {
         .collect::<Vec<_>>();
 
     quote! {
-        impl #name {
-            /// Names of the variants of this enum
-            #[allow(dead_code)]
-            pub const VARIANTS: &'static [&'static str] = &[ #(#names),* ];
-        }
-              
         impl #impl_generics ::strum::VariantNames for #name #ty_generics #where_clause {
-            /// Return a slice containing the names of the variants of this enum
-            #[allow(dead_code)]
-            fn variants() -> &'static [&'static str] {
-                Self::VARIANTS
-            }
+            const VARIANTS: &'static [&'static str] = &[ #(#names),* ];
         }
     }
 }

--- a/strum_tests/tests/enum_variant_names.rs
+++ b/strum_tests/tests/enum_variant_names.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate strum_macros;
 #[macro_use]

--- a/strum_tests/tests/enum_variant_names.rs
+++ b/strum_tests/tests/enum_variant_names.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate strum_macros;
 #[macro_use]
@@ -14,7 +16,8 @@ fn simple() {
         Yellow,
     }
 
-    assert_eq!(&Color::variants(), &["Red", "Blue", "Yellow"]);
+    assert_eq!(Color::VARIANTS, &["Red", "Blue", "Yellow"]);
+    assert_eq!(Color::variants(), &["Red", "Blue", "Yellow"]);
 }
 
 #[test]
@@ -29,10 +32,8 @@ fn plain_kebab() {
         RebeccaPurple,
     }
 
-    assert_eq!(
-        &Color::variants(),
-        &["red", "blue", "yellow", "rebecca-purple"]
-    );
+    assert_eq!(Color::VARIANTS, &["red", "blue", "yellow", "rebecca-purple"]);
+    assert_eq!(Color::variants(), &["red", "blue", "yellow", "rebecca-purple"]);
 }
 
 #[test]
@@ -48,7 +49,11 @@ fn non_plain_camel() {
     }
 
     assert_eq!(
-        &Color::variants(),
+        Color::VARIANTS,
+        &["deep-pink", "green-yellow", "cornflower-blue", "other"]
+    );
+    assert_eq!(
+        Color::variants(),
         &["deep-pink", "green-yellow", "cornflower-blue", "other"]
     );
 }
@@ -65,14 +70,19 @@ fn clap_and_structopt() {
     }
 
     assert_eq!(
-        &Color::variants(),
+        Color::VARIANTS,
+        &["red", "blue", "yellow", "rebecca-purple"]
+    );
+
+    assert_eq!(
+        Color::variants(),
         &["red", "blue", "yellow", "rebecca-purple"]
     );
 
     let _clap_example = clap::App::new("app").arg(
         clap::Arg::with_name("color")
             .long("color")
-            .possible_values(Color::variants())
+            .possible_values(Color::VARIANTS)
             .case_insensitive(true),
     );
 

--- a/strum_tests/tests/enum_variant_names.rs
+++ b/strum_tests/tests/enum_variant_names.rs
@@ -16,7 +16,6 @@ fn simple() {
     }
 
     assert_eq!(Color::VARIANTS, &["Red", "Blue", "Yellow"]);
-    assert_eq!(Color::variants(), &["Red", "Blue", "Yellow"]);
 }
 
 #[test]
@@ -30,7 +29,7 @@ fn variant_names_trait() {
     }
 
     fn generic_function<T: VariantNames>() {
-        assert_eq!(T::variants(), &["Red", "Blue", "Yellow"]);
+        assert_eq!(T::VARIANTS, &["Red", "Blue", "Yellow"]);
     }
 
     generic_function::<Color>();
@@ -49,7 +48,6 @@ fn plain_kebab() {
     }
 
     assert_eq!(Color::VARIANTS, &["red", "blue", "yellow", "rebecca-purple"]);
-    assert_eq!(Color::variants(), &["red", "blue", "yellow", "rebecca-purple"]);
 }
 
 #[test]
@@ -66,10 +64,6 @@ fn non_plain_camel() {
 
     assert_eq!(
         Color::VARIANTS,
-        &["deep-pink", "green-yellow", "cornflower-blue", "other"]
-    );
-    assert_eq!(
-        Color::variants(),
         &["deep-pink", "green-yellow", "cornflower-blue", "other"]
     );
 }
@@ -90,11 +84,6 @@ fn clap_and_structopt() {
         &["red", "blue", "yellow", "rebecca-purple"]
     );
 
-    assert_eq!(
-        Color::variants(),
-        &["red", "blue", "yellow", "rebecca-purple"]
-    );
-
     let _clap_example = clap::App::new("app").arg(
         clap::Arg::with_name("color")
             .long("color")
@@ -109,7 +98,7 @@ fn clap_and_structopt() {
         #[structopt(
             long = "color",
             default_value = "Color::Blue",
-            raw(possible_values = "Color::variants()")
+            raw(possible_values = "Color::VARIANTS")
         )]
         color: Color,
     }


### PR DESCRIPTION
I tried to write code like this:
```rust
pub const LETTERS: &'static [&'static str] = Letter::variants();

#[derive(EnumVariantNames)]
pub enum Letter { A, B, C }
```
But I've found that `variants` fn is not `const`.

This pr changes the behaviour of `EnumVariantNames` in that way:
1. Add `pub const VARIANTS: &'static [&'static str] = ...` to enum
2. make `variants` fn `const`
3. deprecate `variants` fn with a message like ``"Use `Letter::VARIANTS` instead"``