### PR TITLE
Add checks to guard against overflow in iterator methods.

### DIFF
--- a/strum_macros/src/macros/enum_iter.rs
+++ b/strum_macros/src/macros/enum_iter.rs
@@ -83,12 +83,14 @@ pub fn enum_iter_inner(ast: &syn::DeriveInput) -> TokenStream {
                     #(#arms),*
                 };
 
-                self.idx += 1;
+                if self.idx < #variant_count {
+                    self.idx += 1;
+                }
                 output
             }
 
             fn size_hint(&self) -> (usize, Option<usize>) {
-                let t = #variant_count - self.idx;
+                let t = if self.idx >= #variant_count { 0 } else { #variant_count - self.idx };
                 (t, Some(t))
             }
         }

--- a/strum_tests/tests/enum_iter.rs
+++ b/strum_tests/tests/enum_iter.rs
@@ -63,6 +63,9 @@ fn len_test() {
     i.next();
 
     assert_eq!(0, i.len());
+    i.next();
+
+    assert_eq!(0, i.size_hint().1.unwrap());
 }
 
 #[test]


### PR DESCRIPTION
When a generated iterator runs of the end it keeps on incrementing the index variable, which is undesirable. Furthermore the size_hint method does not guard against the index being greater than the variant count, which causes an overflow.

These issues cause our static analyses [tool](https://github.com/facebookexperimental/MIRAI) to generate warnings when analyzing code generated by strum, which is annoying.

Thanks for considering this.