### PR TITLE
Bugfix/73/whitelist variant attributes to copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Only copy across `"doc", "cfg", "allow", "deny"` attributes from main enum variants to discriminant variants. [#73](https://github.com/Peternator7/strum/issues/73)
+
 ## 0.17.1
 
 * Fixed an issue caused by combining [#60](https://github.com/Peternator7/strum/pull/60) and [#76](https://github.com/Peternator7/strum/pull/76)

--- a/strum_tests/Cargo.toml
+++ b/strum_tests/Cargo.toml
@@ -7,4 +7,5 @@ authors = ["Peter Glotfelty <peglotfe@microsoft.com>"]
 strum = { path = "../strum", features = ["derive"] }
 strum_macros = { path = "../strum_macros", features = [] }
 clap = "2.33.0"
+enum_variant_type = "0.2.0"
 structopt = "0.2.18"

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -1,6 +1,8 @@
 extern crate strum;
 #[macro_use]
 extern crate strum_macros;
+#[macro_use]
+extern crate enum_variant_type;
 
 use strum::IntoEnumIterator;
 
@@ -183,4 +185,36 @@ fn from_test_complex() {
 fn from_ref_test_complex() {
     let rara = Rara;
     assert_eq!(EnumIntoComplexVars::A, (&EnumIntoComplex::A(&rara)).into());
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Eq, PartialEq, EnumDiscriminants, EnumVariantType)]
+#[strum_discriminants(
+    name(VariantFilterAttrDiscs),
+    derive(Display, EnumIter, EnumString),
+    strum(serialize_all = "snake_case")
+)]
+enum VariantFilterAttr {
+    #[evt(derive(Clone, Copy, Debug))]
+    DarkBlack(bool),
+    #[evt(skip)]
+    BrightWhite(i32),
+}
+
+#[test]
+fn filter_variant_attributes_pass_through() {
+    use std::str::FromStr;
+
+    let discriminants = VariantFilterAttrDiscs::iter().collect::<Vec<_>>();
+    let expected = vec![
+        VariantFilterAttrDiscs::DarkBlack,
+        VariantFilterAttrDiscs::BrightWhite,
+    ];
+
+    assert_eq!(expected, discriminants);
+    assert_eq!("dark_black", VariantFilterAttrDiscs::DarkBlack.to_string());
+    assert_eq!(
+        VariantFilterAttrDiscs::DarkBlack,
+        VariantFilterAttrDiscs::from_str("dark_black").unwrap()
+    );
 }


### PR DESCRIPTION
Whitelist attributes to copy across from main enum variants to discriminant enum variants.
Currently the whitelist is: `"doc", "cfg", "allow", "deny"`.

Fixes #73

A potential extension (not implemented, but would fix #41) is to allow a `#[strum_discriminant(..)` attribute on each variant, and pass through everything within the `..`, flattening away the `strum_discriminant` layer, and making sure to override any of the whitelisted attributes if present.