### PR TITLE
Apply serialize_all casing to get_serializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Only copy across `"doc", "cfg", "allow", "deny"` attributes from main enum variants to discriminant variants. [#73](https://github.com/Peternator7/strum/issues/73)
 * The formatting of generated serialization variants returned by `get_serializations()` from an
-  enum that derives `EnumMessage` are now affected by the `serialize_all` property on the enum.
+  enum that derives `EnumMessage` is now affected by the `serialize_all` property on the enum.
   [#84](https://github.com/Peternator7/strum/pull/84)
 
 ## 0.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.18.0
+
+* The formatting of generated serialization variants returned by `get_serializations()` from an
+  enum that derives `EnumMessage` are now affected by the `serialize_all` property on the enum.
+  [#84](https://github.com/Peternator7/strum/pull/84)
+
 ## 0.17.1
 
 * Fixed an issue caused by combining [#60](https://github.com/Peternator7/strum/pull/60) and [#76](https://github.com/Peternator7/strum/pull/76)

--- a/strum_tests/tests/enum_message.rs
+++ b/strum_tests/tests/enum_message.rs
@@ -54,3 +54,30 @@ fn disabled_message() {
     assert_eq!(None, (Pets::Hamster).get_message());
     assert_eq!(None, (Pets::Hamster).get_detailed_message());
 }
+
+#[derive(Debug, Eq, PartialEq, EnumMessage)]
+#[strum(serialize_all = "kebab_case")]
+enum Brightness {
+    DarkBlack,
+    Dim {
+        glow: usize,
+    },
+    #[strum(serialize = "bright")]
+    BrightWhite,
+}
+
+#[test]
+fn get_serializations() {
+    assert_eq!(
+        vec!["dark-black"],
+        (Brightness::DarkBlack).get_serializations()
+    );
+    assert_eq!(
+        vec!["dim"],
+        (Brightness::Dim { glow: 1 }).get_serializations()
+    );
+    assert_eq!(
+        vec!["bright"],
+        (Brightness::BrightWhite).get_serializations()
+    );
+}


### PR DESCRIPTION
I'm not sure if this is intentional, but it seems to make sense to convert case for `get_serializations`. When `to_string` is already being used for display you may still want to use the automatic case conversion for serialization. 