### PR TITLE
Add repository link in strum crate Cargo.toml

### DIFF
--- a/strum/Cargo.toml
+++ b/strum/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["development-tools::procedural-macro-helpers", "parsing"]
 
 documentation = "https://docs.rs/strum"
 homepage = "https://github.com/Peternator7/strum"
+repository  = "https://github.com/Peternator7/strum"
 readme = "../README.md"
 
 [dependencies]

--- a/strum/Cargo.toml
+++ b/strum/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["development-tools::procedural-macro-helpers", "parsing"]
 
 documentation = "https://docs.rs/strum"
 homepage = "https://github.com/Peternator7/strum"
-repository  = "https://github.com/Peternator7/strum"
+repository = "https://github.com/Peternator7/strum"
 readme = "../README.md"
 
 [dependencies]


### PR DESCRIPTION
Having a repository link provides a helpful backlink to the crate in docs.rs