### PR TITLE
Update README.md with most recent strum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Cargo.toml. Strum_macros contains the macros needed to derive all the traits in 
 
 ```toml
 [dependencies]
-strum = "0.18.0"
-strum_macros = "0.18.0"
+strum = "0.19"
+strum_macros = "0.19"
 ```
 
 And add these lines to the root of your project, either lib.rs or main.rs.


### PR DESCRIPTION
The README.md hardcoded the version `0.18.0` in the `Cargo.toml` description. This changes it to `0.19` without the patch version, ensuring that it will be accurate until the next minor release.