### PR TITLE
Wiki to examples

### DIFF
--- a/strum/Cargo.toml
+++ b/strum/Cargo.toml
@@ -19,6 +19,7 @@ strum_macros = { path = "../strum_macros", optional = true, version = "0.19.2" }
 
 [dev-dependencies]
 strum_macros = { path = "../strum_macros", version = "0.19.2" }
+structopt = { version = "0.3", default-features = false }
 
 [badges]
 travis-ci = { repository = "Peternator7/strum" }

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -1,0 +1,7 @@
+# Example uses for strum
+
+## EnumVariantNames
+
+This example shows how to use this macro with structopt, you can run it using e.g.:
+
+`cargo run --example enumvariantnames -- --color blue`

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -39,6 +39,14 @@ a `&str` instead of a `String` so you don't allocate any additional memory with 
 
 `cargo run --example asrefstr`
 
+## IntoStaticStr
+
+Implements `From<YourEnum>` and `From<&'a YourEnum>` for `&'static str`. This is
+useful for turning an enum variant into a static string.
+The Rust `std` provides a blanket impl of the reverse direction - i.e. `impl Into<&'static str> for YourEnum`.
+
+`cargo run --example intostaticstr`
+
 ## EnumVariantNames
 
 Adds an `impl` block for the `enum` that adds a static `VARIANTS` array of `&'static str` that are the discriminant names.

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -64,3 +64,15 @@ You cannot derive `EnumIter` on any type with a lifetime bound (`<'a>`) because 
 create [unbounded lifetimes](https://doc.rust-lang.org/nightly/nomicon/unbounded-lifetimes.html).
 
 `cargo run --example enumiter`
+
+## EnumProperty
+
+Enables the encoding of arbitary constants into enum variants. This method
+currently only supports adding additional string values. Other types of literals are still
+experimental in the rustc compiler. The generated code works by nesting match statements.
+The first match statement matches on the type of the enum, and the inner match statement
+matches on the name of the property requested. This design works well for enums with a small
+number of variants and properties, but scales linearly with the number of variants so may not
+be the best choice in all situations.
+
+`cargo run --example enumproperty`

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -92,3 +92,12 @@ non-`Default` fields. By default, the generated enum has the following derives:
 `#[strum_discriminants(derive(AdditionalDerive))]` attribute.
 
 `cargo run --example enumdiscriminants`
+
+## EnumCount
+
+For a given enum generates implementation of `strum::EnumCount`,
+which returns number of variants via `strum::EnumCount::count` method,
+also for given `enum MyEnum` generates `const MYENUM_COUNT: usize`
+which gives the same value as `strum::EnumCount` (which is usefull for array sizes, etc.).
+
+`cargo run --example enumcount`

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -29,6 +29,16 @@ from enum into string and back again for unit style variants.
     behavior isn't desired, you should use `to_string`.
 3. The name of the variant will be used if there are no `serialize` or `to_string` attributes.
 
+`cargo run --example display`
+
+## AsRefStr
+
+Implements `AsRef<str>` on your enum using the same rules as
+`Display` for determining what string is returned. The difference is that `as_ref()` returns
+a `&str` instead of a `String` so you don't allocate any additional memory with each call.
+
+`cargo run --example asrefstr`
+
 ## EnumVariantNames
 
 Adds an `impl` block for the `enum` that adds a static `VARIANTS` array of `&'static str` that are the discriminant names.

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -18,6 +18,17 @@ Section for more information on using this feature.
 
 `cargo run --example enumstring`
 
+## Display
+
+Deriving `Display` on an enum prints out the given enum. This enables you to perform round trip style conversions
+from enum into string and back again for unit style variants.
+`Display` choose which serialization to used based on the following criteria:
+
+1. If there is a `to_string` property, this value will be used. There can only be one per variant.
+2. Of the various `serialize` properties, the value with the longest length is chosen. If that
+    behavior isn't desired, you should use `to_string`.
+3. The name of the variant will be used if there are no `serialize` or `to_string` attributes.
+
 ## EnumVariantNames
 
 Adds an `impl` block for the `enum` that adds a static `VARIANTS` array of `&'static str` that are the discriminant names.

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -80,3 +80,15 @@ be the best choice in all situations.
 ## EnumMessage
 
 please read the source code of `examples/enummessage.rs` to get more details
+
+`cargo run --example enummessage`
+
+## EnumDiscriminants
+
+Given an enum named `MyEnum`, generates another enum called `MyEnumDiscriminants` with the same variants, without any data fields.
+This is useful when you wish to determine the variant of an enum from a String, but the variants contain any
+non-`Default` fields. By default, the generated enum has the following derives:
+`Clone, Copy, Debug, PartialEq, Eq`. You can add additional derives using the
+`#[strum_discriminants(derive(AdditionalDerive))]` attribute.
+
+`cargo run --example enumdiscriminants`

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -96,8 +96,6 @@ non-`Default` fields. By default, the generated enum has the following derives:
 ## EnumCount
 
 For a given enum generates implementation of `strum::EnumCount`,
-which returns number of variants via `strum::EnumCount::count` method,
-also for given `enum MyEnum` generates `const MYENUM_COUNT: usize`
-which gives the same value as `strum::EnumCount` (which is usefull for array sizes, etc.).
+which adds a static property `COUNT` of type usize that holds the number of variants,
 
 `cargo run --example enumcount`

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -56,3 +56,11 @@ This example shows how to use this macro with structopt, you can run it using e.
 
 `cargo run --example enumvariantnames -- --color blue`
 
+## EnumIter
+
+Iterate over the variants of an Enum. Any additional data on your variants will be set to `Default::default()`.
+The macro implements `strum::IntoEnumIter` on your enum and creates a new type called `YourEnumIter` that is the iterator object.
+You cannot derive `EnumIter` on any type with a lifetime bound (`<'a>`) because the iterator would surely
+create [unbounded lifetimes](https://doc.rust-lang.org/nightly/nomicon/unbounded-lifetimes.html).
+
+`cargo run --example enumiter`

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -1,7 +1,29 @@
 # Example uses for strum
 
+## EnumString
+
+auto-derives `std::str::FromStr` on the enum. Each variant of the enum will match on it's own name.
+This can be overridden using `serialize="DifferentName"` or `to_string="DifferentName"`
+on the attribute as shown below.
+Multiple deserializations can be added to the same variant. If the variant contains additional data,
+they will be set to their default values upon deserialization.
+
+The `default` attribute can be applied to a tuple variant with a single data parameter. When a match isn't
+found, the given variant will be returned and the input string will be captured in the parameter.
+
+Note that the implementation of `FromStr` by default only matches on the name of the
+variant. There is an option to match on different case conversions through the
+`#[strum(serialize_all = "snake_case")]` type attribute. See the [Additional Attributes](https://github.com/Peternator7/strum/wiki/Additional-Attributes)
+Section for more information on using this feature.
+
+`cargo run --example enumstring`
+
 ## EnumVariantNames
+
+Adds an `impl` block for the `enum` that adds a static `VARIANTS` array of `&'static str` that are the discriminant names.
+This will respect the `serialize_all` attribute on the `enum` (like `#[strum(serialize_all = "snake_case")]`, see **Additional Attributes** in the examples source code).
 
 This example shows how to use this macro with structopt, you can run it using e.g.:
 
 `cargo run --example enumvariantnames -- --color blue`
+

--- a/strum/examples/README.md
+++ b/strum/examples/README.md
@@ -76,3 +76,7 @@ number of variants and properties, but scales linearly with the number of varian
 be the best choice in all situations.
 
 `cargo run --example enumproperty`
+
+## EnumMessage
+
+please read the source code of `examples/enummessage.rs` to get more details

--- a/strum/examples/asrefstr.rs
+++ b/strum/examples/asrefstr.rs
@@ -1,0 +1,29 @@
+// You need to bring the AsRef trait into scope to use it
+use std::convert::AsRef;
+use strum_macros::AsRefStr;
+
+#[derive(AsRefStr, Debug)]
+enum Color {
+    #[strum(serialize = "redred")]
+    Red,
+    Green {
+        range: usize,
+    },
+    Blue(usize),
+    Yellow,
+}
+
+fn main() {
+    // uses the serialize string for Display
+    let red = Color::Red;
+    assert_eq!("redred", red.as_ref());
+    // by default the variants Name
+    let yellow = Color::Yellow;
+    assert_eq!("Yellow", yellow.as_ref());
+    // or for string formatting
+    println!(
+        "blue: {} green: {}",
+        Color::Blue(10).as_ref(),
+        Color::Green { range: 42 }.as_ref()
+    );
+}

--- a/strum/examples/display.rs
+++ b/strum/examples/display.rs
@@ -1,0 +1,29 @@
+// You need to bring the ToString trait into scope to use it
+use std::string::ToString;
+use strum_macros::Display;
+
+#[derive(Display, Debug)]
+enum Color {
+    #[strum(serialize = "redred")]
+    Red,
+    Green {
+        range: usize,
+    },
+    Blue(usize),
+    Yellow,
+}
+
+fn main() {
+    // uses the serialize string for Display
+    let red = Color::Red;
+    assert_eq!(String::from("redred"), red.to_string());
+    // by default the variants Name
+    let yellow = Color::Yellow;
+    assert_eq!(String::from("Yellow"), yellow.to_string());
+    // or for string formatting
+    println!(
+        "blue: {} green: {}",
+        Color::Blue(10),
+        Color::Green { range: 42 }
+    );
+}

--- a/strum/examples/enumcount.rs
+++ b/strum/examples/enumcount.rs
@@ -1,0 +1,18 @@
+use strum::{EnumCount, IntoEnumIterator};
+use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
+
+#[derive(Debug, EnumCountMacro, EnumIter)]
+enum Week {
+    Sunday,
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+}
+
+fn main() {
+    assert_eq!(7, Week::COUNT);
+    assert_eq!(Week::iter().count(), Week::COUNT);
+}

--- a/strum/examples/enumdiscriminants.rs
+++ b/strum/examples/enumdiscriminants.rs
@@ -1,0 +1,39 @@
+// Bring trait into scope
+use std::str::FromStr;
+use strum::IntoEnumIterator;
+use strum_macros::{EnumDiscriminants, EnumIter, EnumString};
+
+#[derive(Debug)]
+struct NonDefault;
+
+// simple example
+#[allow(dead_code)]
+#[derive(Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumString))]
+enum MyEnum {
+    Variant0(NonDefault),
+    Variant1 { a: NonDefault },
+}
+
+// You can also rename the generated enum using the `#[strum_discriminants(name(OtherName))]` attribute:
+#[allow(dead_code)]
+#[derive(Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
+#[strum_discriminants(name(MyVariants))]
+enum MyEnumR {
+    Variant0(bool),
+    Variant1 { a: bool },
+}
+
+fn main() {
+    // test simple example
+    assert_eq!(
+        MyEnumDiscriminants::Variant0,
+        MyEnumDiscriminants::from_str("Variant0").unwrap()
+    );
+    // test rename example combined with EnumIter
+    assert_eq!(
+        vec![MyVariants::Variant0, MyVariants::Variant1],
+        MyVariants::iter().collect::<Vec<_>>()
+    );
+}

--- a/strum/examples/enumiter.rs
+++ b/strum/examples/enumiter.rs
@@ -1,0 +1,22 @@
+// You need to bring the trait into scope to use it!
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
+#[derive(EnumIter, Debug)]
+enum Color {
+    Red,
+    Green { range: usize },
+    Blue(usize),
+    Yellow,
+}
+
+// It's simple to iterate over the variants of an enum.
+fn debug_colors() {
+    for color in Color::iter() {
+        println!("My favorite color is {:?}", color);
+    }
+}
+
+fn main() {
+    debug_colors();
+}

--- a/strum/examples/enummessage.rs
+++ b/strum/examples/enummessage.rs
@@ -4,9 +4,9 @@
 
 // You need to bring the trait into scope to use it!!!
 use strum::EnumMessage;
-use strum_macros::EnumMessage;
+use strum_macros;
 
-#[derive(EnumMessage, Debug)]
+#[derive(strum_macros::EnumMessage, Debug)]
 #[allow(dead_code)]
 enum Color {
     #[strum(message = "Red", detailed_message = "This is very red")]

--- a/strum/examples/enummessage.rs
+++ b/strum/examples/enummessage.rs
@@ -1,0 +1,62 @@
+//! Encode strings into the enum itself. The `strum_macros::EmumMessage` macro implements the `strum::EnumMessage` trait.
+//! `EnumMessage` looks for `#[strum(message="...")]` attributes on your variants.
+//! You can also provided a `detailed_message="..."` attribute to create a seperate more detailed message than the first.
+
+// You need to bring the trait into scope to use it!!!
+use strum::EnumMessage;
+use strum_macros::EnumMessage;
+
+#[derive(EnumMessage, Debug)]
+#[allow(dead_code)]
+enum Color {
+    #[strum(message = "Red", detailed_message = "This is very red")]
+    Red,
+    #[strum(message = "Simply Green")]
+    Green { range: usize },
+    #[strum(serialize = "b", serialize = "blue")]
+    Blue(usize),
+}
+
+// Generated code looks like more or less like this:
+/*
+impl ::strum::EnumMessage for Color {
+    fn get_message(&self) -> ::std::option::Option<&str> {
+        match self {
+            &Color::Red => ::std::option::Option::Some("Red"),
+            &Color::Green {..} => ::std::option::Option::Some("Simply Green"),
+            _ => None
+        }
+    }
+
+    fn get_detailed_message(&self) -> ::std::option::Option<&str> {
+        match self {
+            &Color::Red => ::std::option::Option::Some("This is very red"),
+            &Color::Green {..}=> ::std::option::Option::Some("Simply Green"),
+            _ => None
+        }
+    }
+
+    fn get_serializations(&self) -> &[&str] {
+        match self {
+            &Color::Red => {
+                static ARR: [&'static str; 1] = ["Red"];
+                &ARR
+            },
+            &Color::Green {..}=> {
+                static ARR: [&'static str; 1] = ["Green"];
+                &ARR
+            },
+            &Color::Blue (..) => {
+                static ARR: [&'static str; 2] = ["b", "blue"];
+                &ARR
+            },
+        }
+    }
+}
+*/
+fn main() {
+    let c = Color::Red;
+    println!("{}", c.get_message().unwrap());
+    println!("{}", c.get_detailed_message().unwrap());
+    println!("{:?}", c.get_serializations());
+}

--- a/strum/examples/enumproperty.rs
+++ b/strum/examples/enumproperty.rs
@@ -1,0 +1,30 @@
+use strum_macros::EnumProperty;
+// bring the trait into scope
+use strum::EnumProperty;
+
+#[derive(EnumProperty, Debug)]
+#[allow(dead_code)]
+enum Color {
+    #[strum(props(Red = "255", Blue = "255", Green = "255"))]
+    White,
+    #[strum(props(Red = "0", Blue = "0", Green = "0"))]
+    Black,
+    #[strum(props(Red = "0", Blue = "255", Green = "0"))]
+    Blue,
+    #[strum(props(Red = "255", Blue = "0", Green = "0"))]
+    Red,
+    #[strum(props(Red = "0", Blue = "0", Green = "255"))]
+    Green,
+}
+
+fn main() {
+    let my_color = Color::Red;
+    let display = format!(
+        "My color is {:?}. It's RGB is {},{},{}",
+        my_color,
+        my_color.get_str("Red").unwrap(),
+        my_color.get_str("Green").unwrap(),
+        my_color.get_str("Blue").unwrap()
+    );
+    println!("{}", display);
+}

--- a/strum/examples/enumproperty.rs
+++ b/strum/examples/enumproperty.rs
@@ -1,8 +1,8 @@
-use strum_macros::EnumProperty;
+use strum_macros;
 // bring the trait into scope
 use strum::EnumProperty;
 
-#[derive(EnumProperty, Debug)]
+#[derive(strum_macros::EnumProperty, Debug)]
 #[allow(dead_code)]
 enum Color {
     #[strum(props(Red = "255", Blue = "255", Green = "255"))]

--- a/strum/examples/enumstring.rs
+++ b/strum/examples/enumstring.rs
@@ -1,0 +1,51 @@
+//! Example howto use EnumString
+
+use std::str::FromStr;
+use strum_macros::EnumString;
+
+#[derive(Debug, PartialEq, EnumString)]
+enum Color {
+    Red,
+    // The Default value will be inserted into range if we match "Green".
+    Green {
+        range: usize,
+    },
+
+    // We can match on multiple different patterns.
+    #[strum(serialize = "blue", serialize = "b")]
+    Blue(usize),
+
+    // Notice that we can disable certain variants from being found
+    #[strum(disabled)]
+    Yellow,
+}
+
+/*
+//The generated code will look like:
+impl std::str::FromStr for Color {
+    type Err = ::strum::ParseError;
+
+    fn from_str(s: &str) -> ::std::result::Result<Color, Self::Err> {
+        match s {
+            "Red" => ::std::result::Result::Ok(Color::Red),
+            "Green" => ::std::result::Result::Ok(Color::Green { range:Default::default() }),
+            "blue" | "b" => ::std::result::Result::Ok(Color::Blue(Default::default())),
+            _ => ::std::result::Result::Err(::strum::ParseError::VariantNotFound),
+        }
+    }
+}
+*/
+
+fn main() {
+    // simple from string
+    let color_variant = Color::from_str("Red").unwrap();
+    assert_eq!(Color::Red, color_variant);
+    // short version works too
+    let color_variant = Color::from_str("b").unwrap();
+    assert_eq!(Color::Blue(0), color_variant);
+    // was disabled for parsing = returns parse-error
+    let color_variant = Color::from_str("Yellow");
+    assert!(color_variant.is_err());
+    // however the variant is still normally usable
+    println!("{:?}", Color::Yellow);
+}

--- a/strum/examples/enumvariantnames.rs
+++ b/strum/examples/enumvariantnames.rs
@@ -1,0 +1,42 @@
+//! Example howto use EnumVariantNames for structopt
+
+// import the macros needed
+use strum_macros::{EnumString, EnumVariantNames};
+// You need to import the trait, to have access to VARIANTS
+use structopt::StructOpt;
+use strum::VariantNames;
+
+#[derive(Debug, EnumString, EnumVariantNames)]
+#[strum(serialize_all = "kebab_case")]
+enum Color {
+    Red,
+    Blue,
+    Yellow,
+    RebeccaPurple,
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "EnumVariantNames",
+    about = "example use of EnumVariantNames macro for structopt."
+)]
+struct Opt {
+    /// Activate debug mode
+    #[structopt(short, long)]
+    debug: bool,
+
+    /// Select color
+    #[structopt(long, possible_values = &Color::VARIANTS)]
+    color: Color,
+}
+
+fn main() {
+    // verify variants
+    assert_eq!(
+        &Color::VARIANTS,
+        &["red", "blue", "yellow", "rebecca-purple"]
+    );
+    // parse args and show them
+    let opt = Opt::from_args();
+    println!("options used debug: {} color: {:?}", opt.debug, opt.color);
+}

--- a/strum/examples/intostaticstr.rs
+++ b/strum/examples/intostaticstr.rs
@@ -1,0 +1,23 @@
+use strum_macros::IntoStaticStr;
+
+#[derive(IntoStaticStr)]
+enum State<'a> {
+    Initial(&'a str),
+    Finished,
+}
+
+fn print_state<'a>(s: &'a str) {
+    let mut state = State::Initial(s);
+    // The following won't work because the lifetime is incorrect:
+    // let wrong: &'static str = state.as_ref();
+    // using the trait implemented by the derive works however:
+    let right: &'static str = state.into();
+    println!("{}", right);
+    state = State::Finished;
+    let done: &'static str = state.into();
+    println!("{}", done);
+}
+
+fn main() {
+    print_state(&"hello world".to_string())
+}


### PR DESCRIPTION
This is in response to Issue #115 
I made all examples work and compile without warning. I put them all in the idiomatic examples/ folder, easy to run and compile using `cargo run --example`

descriptive text is in examples/README.md where sensible and in code non-obvious stuff is described in comments.