### PR TITLE
Replaced ::std with ::core where applicable for no_std projects

### DIFF
--- a/strum_macros/src/macros/enum_discriminants.rs
+++ b/strum_macros/src/macros/enum_discriminants.rs
@@ -99,7 +99,7 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let impl_from = quote! {
-        impl #impl_generics ::std::convert::From< #name #ty_generics > for #discriminants_name #where_clause {
+        impl #impl_generics ::core::convert::From< #name #ty_generics > for #discriminants_name #where_clause {
             fn from(val: #name #ty_generics) -> #discriminants_name {
                 #from_fn_body
             }
@@ -116,7 +116,7 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         let (impl_generics, _, _) = generics.split_for_impl();
 
         quote! {
-            impl #impl_generics ::std::convert::From< #enum_life #name #ty_generics > for #discriminants_name #where_clause {
+            impl #impl_generics ::core::convert::From< #enum_life #name #ty_generics > for #discriminants_name #where_clause {
                 fn from(val: #enum_life #name #ty_generics) -> #discriminants_name {
                     #from_fn_body
                 }

--- a/strum_macros/src/macros/enum_iter.rs
+++ b/strum_macros/src/macros/enum_iter.rs
@@ -43,7 +43,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         let params = match &variant.fields {
             Unit => quote! {},
             Unnamed(fields) => {
-                let defaults = ::std::iter::repeat(quote!(::std::default::Default::default()))
+                let defaults = ::std::iter::repeat(quote!(::core::default::Default::default()))
                     .take(fields.unnamed.len());
                 quote! { (#(#defaults),*) }
             }
@@ -52,16 +52,16 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                     .named
                     .iter()
                     .map(|field| field.ident.as_ref().unwrap());
-                quote! { {#(#fields: ::std::default::Default::default()),*} }
+                quote! { {#(#fields: ::core::default::Default::default()),*} }
             }
         };
 
-        arms.push(quote! {#idx => ::std::option::Option::Some(#name::#ident #params)});
+        arms.push(quote! {#idx => ::core::option::Option::Some(#name::#ident #params)});
         idx += 1;
     }
 
     let variant_count = arms.len();
-    arms.push(quote! { _ => ::std::option::Option::None });
+    arms.push(quote! { _ => ::core::option::Option::None });
     let iter_name = syn::parse_str::<Ident>(&format!("{}Iter", name)).unwrap();
 
     Ok(quote! {
@@ -69,7 +69,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         #vis struct #iter_name #ty_generics {
             idx: usize,
             back_idx: usize,
-            marker: ::std::marker::PhantomData #phantom_data,
+            marker: ::core::marker::PhantomData #phantom_data,
         }
 
         impl #impl_generics #iter_name #ty_generics #where_clause {
@@ -86,7 +86,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                 #iter_name {
                     idx: 0,
                     back_idx: 0,
-                    marker: ::std::marker::PhantomData,
+                    marker: ::core::marker::PhantomData,
                 }
             }
         }

--- a/strum_macros/src/macros/enum_messages.rs
+++ b/strum_macros/src/macros/enum_messages.rs
@@ -54,7 +54,7 @@ pub fn enum_message_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             let params = params.clone();
 
             // Push the simple message.
-            let tokens = quote! { &#name::#ident #params => ::std::option::Option::Some(#msg) };
+            let tokens = quote! { &#name::#ident #params => ::core::option::Option::Some(#msg) };
             arms.push(tokens.clone());
 
             if detailed_messages.is_none() {
@@ -66,27 +66,27 @@ pub fn enum_message_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             let params = params.clone();
             // Push the simple message.
             detailed_arms
-                .push(quote! { &#name::#ident #params => ::std::option::Option::Some(#msg) });
+                .push(quote! { &#name::#ident #params => ::core::option::Option::Some(#msg) });
         }
     }
 
     if arms.len() < variants.len() {
-        arms.push(quote! { _ => ::std::option::Option::None });
+        arms.push(quote! { _ => ::core::option::Option::None });
     }
 
     if detailed_arms.len() < variants.len() {
-        detailed_arms.push(quote! { _ => ::std::option::Option::None });
+        detailed_arms.push(quote! { _ => ::core::option::Option::None });
     }
 
     Ok(quote! {
         impl #impl_generics ::strum::EnumMessage for #name #ty_generics #where_clause {
-            fn get_message(&self) -> ::std::option::Option<&str> {
+            fn get_message(&self) -> ::core::option::Option<&str> {
                 match self {
                     #(#arms),*
                 }
             }
 
-            fn get_detailed_message(&self) -> ::std::option::Option<&str> {
+            fn get_detailed_message(&self) -> ::core::option::Option<&str> {
                 match self {
                     #(#detailed_arms),*
                 }

--- a/strum_macros/src/macros/enum_properties.rs
+++ b/strum_macros/src/macros/enum_properties.rs
@@ -32,12 +32,12 @@ pub fn enum_properties_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         };
 
         for (key, value) in variant_properties.string_props {
-            string_arms.push(quote! { #key => ::std::option::Option::Some( #value )})
+            string_arms.push(quote! { #key => ::core::option::Option::Some( #value )})
         }
 
-        string_arms.push(quote! { _ => ::std::option::Option::None });
-        bool_arms.push(quote! { _ => ::std::option::Option::None });
-        num_arms.push(quote! { _ => ::std::option::Option::None });
+        string_arms.push(quote! { _ => ::core::option::Option::None });
+        bool_arms.push(quote! { _ => ::core::option::Option::None });
+        num_arms.push(quote! { _ => ::core::option::Option::None });
 
         arms.push(quote! {
             &#name::#ident #params => {
@@ -49,12 +49,12 @@ pub fn enum_properties_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     }
 
     if arms.len() < variants.len() {
-        arms.push(quote! { _ => ::std::option::Option::None });
+        arms.push(quote! { _ => ::core::option::Option::None });
     }
 
     Ok(quote! {
         impl #impl_generics ::strum::EnumProperty for #name #ty_generics #where_clause {
-            fn get_str(&self, prop: &str) -> ::std::option::Option<&'static str> {
+            fn get_str(&self, prop: &str) -> ::core::option::Option<&'static str> {
                 match self {
                     #(#arms),*
                 }

--- a/strum_macros/src/macros/strings/as_ref_str.rs
+++ b/strum_macros/src/macros/strings/as_ref_str.rs
@@ -53,7 +53,7 @@ pub fn as_ref_str_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let arms = get_arms(ast)?;
     Ok(quote! {
-        impl #impl_generics ::std::convert::AsRef<str> for #name #ty_generics #where_clause {
+        impl #impl_generics ::core::convert::AsRef<str> for #name #ty_generics #where_clause {
             fn as_ref(&self) -> &str {
                 match *self {
                     #(#arms),*
@@ -97,14 +97,14 @@ pub fn as_static_str_inner(
             }
         },
         GenerateTraitVariant::From => quote! {
-            impl #impl_generics ::std::convert::From<#name #ty_generics> for &'static str #where_clause {
+            impl #impl_generics ::core::convert::From<#name #ty_generics> for &'static str #where_clause {
                 fn from(x: #name #ty_generics) -> &'static str {
                     match x {
                         #(#arms2),*
                     }
                 }
             }
-            impl #impl_generics2 ::std::convert::From<&'_derivative_strum #name #ty_generics> for &'static str #where_clause {
+            impl #impl_generics2 ::core::convert::From<&'_derivative_strum #name #ty_generics> for &'static str #where_clause {
                 fn from(x: &'_derivative_strum #name #ty_generics) -> &'static str {
                     match *x {
                         #(#arms3),*

--- a/strum_macros/src/macros/strings/display.rs
+++ b/strum_macros/src/macros/strings/display.rs
@@ -40,8 +40,8 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     }
 
     Ok(quote! {
-        impl #impl_generics ::std::fmt::Display for #name #ty_generics #where_clause {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+        impl #impl_generics ::core::fmt::Display for #name #ty_generics #where_clause {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::result::Result<(), ::core::fmt::Error> {
                 match *self {
                     #(#arms),*
                 }


### PR DESCRIPTION
This makes these procedural macros usable with `no_std` projects.