### PR TITLE
Use minor version in the README docs.rs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ information through strings.
 Strumming is also a very whimsical motion, much like writing Rust code.
 
 [Macro-Renames]: https://github.com/Peternator7/strum/wiki/Macro-Renames
-[EnumString]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.EnumString.html
-[Display]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.Display.html
-[AsRefStr]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.AsRefStr.html
-[IntoStaticStr]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.IntoStaticStr.html
-[EnumVariantNames]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.EnumVariantNames.html
-[EnumIter]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.EnumIter.html
-[EnumProperty]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.EnumProperty.html
-[EnumMessage]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.EnumMessage.html
-[EnumDiscriminants]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.EnumDiscriminants.html
-[EnumCount]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.EnumCount.html
-[ToString]: https://docs.rs/strum_macros/0.20.0/strum_macros/derive.ToString.html
+[EnumString]: https://docs.rs/strum_macros/0.20/strum_macros/derive.EnumString.html
+[Display]: https://docs.rs/strum_macros/0.20/strum_macros/derive.Display.html
+[AsRefStr]: https://docs.rs/strum_macros/0.20/strum_macros/derive.AsRefStr.html
+[IntoStaticStr]: https://docs.rs/strum_macros/0.20/strum_macros/derive.IntoStaticStr.html
+[EnumVariantNames]: https://docs.rs/strum_macros/0.20/strum_macros/derive.EnumVariantNames.html
+[EnumIter]: https://docs.rs/strum_macros/0.20/strum_macros/derive.EnumIter.html
+[EnumProperty]: https://docs.rs/strum_macros/0.20/strum_macros/derive.EnumProperty.html
+[EnumMessage]: https://docs.rs/strum_macros/0.20/strum_macros/derive.EnumMessage.html
+[EnumDiscriminants]: https://docs.rs/strum_macros/0.20/strum_macros/derive.EnumDiscriminants.html
+[EnumCount]: https://docs.rs/strum_macros/0.20/strum_macros/derive.EnumCount.html
+[ToString]: https://docs.rs/strum_macros/0.20/strum_macros/derive.ToString.html


### PR DESCRIPTION
This fix closes #146.

In #146, I mentioned that an asterisk could be used to just link to the latest version. If this is preferred, please request those changes in a review (or like drop a thumbs down on this message or something).

Thank you!