### PR TITLE
Document the existence of the auto-From implementations

### DIFF
--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -562,13 +562,13 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 
 /// Generate a new type with only the discriminant names.
 ///
-/// Given an enum named `MyEnum`, generates another enum called `MyEnumDiscriminants` with the same variants but without any data fields.
-/// This is useful when you wish to determine the variant of an `enum` from a `String`, but one or more of the variants contains a
-/// non-`Default` field.
+/// Given an enum named `MyEnum`, generates another enum called `MyEnumDiscriminants` with the same
+/// variants but without any data fields. This is useful when you wish to determine the variant of
+/// an `enum` from a `String`, but one or more of the variants contains a non-`Default` field.
 ///
-/// By default, the generated enum has the following derives:
-/// `Clone, Copy, Debug, PartialEq, Eq`. You can add additional derives using the
-/// `#[strum_discriminants(derive(AdditionalDerive))]` attribute.
+/// By default, the generated enum has the following derives: `Clone, Copy, Debug, PartialEq, Eq`.
+/// You can add additional derives using the `#[strum_discriminants(derive(AdditionalDerive))]`
+/// attribute.
 ///
 /// ```
 /// // Bring trait into scope

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -564,7 +564,9 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 ///
 /// Given an enum named `MyEnum`, generates another enum called `MyEnumDiscriminants` with the same
 /// variants but without any data fields. This is useful when you wish to determine the variant of
-/// an `enum` from a `String`, but one or more of the variants contains a non-`Default` field.
+/// an `enum` but one or more of the variants contains a non-`Default` field. `From`
+/// implementations are generated so that you can easily convert from `MyEnum` to
+/// `MyEnumDiscriminants`.
 ///
 /// By default, the generated enum has the following derives: `Clone, Copy, Debug, PartialEq, Eq`.
 /// You can add additional derives using the `#[strum_discriminants(derive(AdditionalDerive))]`
@@ -607,6 +609,17 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 /// assert_eq!(
 ///     vec![MyVariants::Variant0, MyVariants::Variant1],
 ///     MyVariants::iter().collect::<Vec<_>>()
+/// );
+///
+/// // Make use of the auto-From conversion to check whether an instance of `MyEnum` matches a
+/// // `MyEnumDiscriminants` discriminant.
+/// assert_eq!(
+///     MyEnumDiscriminants::Variant0,
+///     MyEnum::Variant0(NonDefault).into()
+/// );
+/// assert_eq!(
+///     MyEnumDiscriminants::Variant0,
+///     MyEnumDiscriminants::from(MyEnum::Variant0(NonDefault))
 /// );
 /// ```
 ///

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -562,9 +562,11 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 
 /// Generate a new type with only the discriminant names.
 ///
-/// Given an enum named `MyEnum`, generates another enum called `MyEnumDiscriminants` with the same variants, without any data fields.
-/// This is useful when you wish to determine the variant of an enum from a String, but the variants contain any
-/// non-`Default` fields. By default, the generated enum has the following derives:
+/// Given an enum named `MyEnum`, generates another enum called `MyEnumDiscriminants` with the same variants but without any data fields.
+/// This is useful when you wish to determine the variant of an `enum` from a `String`, but one or more of the variants contains a
+/// non-`Default` field.
+///
+/// By default, the generated enum has the following derives:
 /// `Clone, Copy, Debug, PartialEq, Eq`. You can add additional derives using the
 /// `#[strum_discriminants(derive(AdditionalDerive))]` attribute.
 ///


### PR DESCRIPTION
`strum_discriminants` auto-generates `From` implementations allowing you to easily convert from the original `enum` to the simplified `enum`, but this wasn't documented (I ended up hunting in the source code to check it was possible!). To help the next person who wonders if this is possible, this PR documents that (https://github.com/Peternator7/strum/commit/78899d91f3a0507dca6b399bcfd242659a7b0ff7), but since I was here anyway I couldn't help myself slightly tweaking the doc comment a bit (with the meaningful change in https://github.com/Peternator7/strum/commit/c2dc22ac30b06edefa72e55d5754177920e2723d and a simple reformatting in https://github.com/Peternator7/strum/commit/687bae5307e44d14f89106c591f506b0b81d7eef).