### PR TITLE
Added a pass-through attribute support to EnumDiscriminants

### DIFF
--- a/strum_macros/src/helpers/mod.rs
+++ b/strum_macros/src/helpers/mod.rs
@@ -9,9 +9,17 @@ pub mod variant_props;
 
 use proc_macro2::Span;
 use quote::ToTokens;
+use syn::spanned::Spanned;
 
 pub fn non_enum_error() -> syn::Error {
     syn::Error::new(Span::call_site(), "This macro only supports enums.")
+}
+
+pub fn strum_discriminants_passthrough_error(span: impl Spanned) -> syn::Error {
+    syn::Error::new(
+        span.span(),
+        "expected a pass-through attribute, e.g. #[strum_discriminants(serde(rename = \"var0\"))]",
+    )
 }
 
 pub fn occurrence_error<T: ToTokens>(fst: T, snd: T, attr: &str) -> syn::Error {

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -572,11 +572,16 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 /// You can add additional derives using the `#[strum_discriminants(derive(AdditionalDerive))]`
 /// attribute.
 ///
+/// Note, the variant attributes passed to the discriminant enum are filtered to avoid compilation
+/// errors due to the derives mismatches, thus only `#[doc]`, `#[cfg]`, `#[allow]`, and `#[deny]`
+/// are passed through by default. If you want to specify a custom attribute on the discriminant
+/// variant, wrap it with `#[strum_discriminants(...)]` attribute.
+///
 /// ```
 /// // Bring trait into scope
 /// use std::str::FromStr;
-/// use strum::IntoEnumIterator;
-/// use strum_macros::{EnumDiscriminants, EnumIter, EnumString};
+/// use strum::{IntoEnumIterator, EnumMessage};
+/// use strum_macros::{EnumDiscriminants, EnumIter, EnumString, EnumMessage};
 ///
 /// #[derive(Debug)]
 /// struct NonDefault;
@@ -584,8 +589,9 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 /// // simple example
 /// # #[allow(dead_code)]
 /// #[derive(Debug, EnumDiscriminants)]
-/// #[strum_discriminants(derive(EnumString))]
+/// #[strum_discriminants(derive(EnumString, EnumMessage))]
 /// enum MyEnum {
+///     #[strum_discriminants(strum(message = "Variant zero"))]
 ///     Variant0(NonDefault),
 ///     Variant1 { a: NonDefault },
 /// }
@@ -620,6 +626,12 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 /// assert_eq!(
 ///     MyEnumDiscriminants::Variant0,
 ///     MyEnumDiscriminants::from(MyEnum::Variant0(NonDefault))
+/// );
+///
+/// // Make use of the EnumMessage on the `MyEnumDiscriminants` discriminant.
+/// assert_eq!(
+///     MyEnumDiscriminants::Variant0.get_message(),
+///     Some("Variant zero")
 /// );
 /// ```
 ///

--- a/strum_macros/src/macros/enum_discriminants.rs
+++ b/strum_macros/src/macros/enum_discriminants.rs
@@ -1,15 +1,15 @@
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
+use proc_macro2::{Span, TokenStream, TokenTree};
+use quote::{quote, ToTokens};
 use syn::parse_quote;
 use syn::{Data, DeriveInput};
 
-use crate::helpers::{non_enum_error, HasTypeProperties};
+use crate::helpers::{non_enum_error, strum_discriminants_passthrough_error, HasTypeProperties};
 
 /// Attributes to copy from the main enum's variants to the discriminant enum's variants.
 ///
 /// Attributes not in this list may be for other `proc_macro`s on the main enum, and may cause
 /// compilation problems when copied across.
-const ATTRIBUTES_TO_COPY: &[&str] = &["doc", "cfg", "allow", "deny"];
+const ATTRIBUTES_TO_COPY: &[&str] = &["doc", "cfg", "allow", "deny", "strum_discriminants"];
 
 pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
@@ -36,7 +36,9 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     );
 
     let discriminants_name = type_properties.discriminant_name.unwrap_or(default_name);
-    let discriminants_vis = type_properties.discriminant_vis.unwrap_or_else(|| vis.clone());
+    let discriminants_vis = type_properties
+        .discriminant_vis
+        .unwrap_or_else(|| vis.clone());
 
     // Pass through all other attributes
     let pass_though_attributes = type_properties.discriminant_others;
@@ -46,12 +48,39 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     for variant in variants {
         let ident = &variant.ident;
 
-        // Don't copy across the "strum" meta attribute.
-        let attrs = variant.attrs.iter().filter(|attr| {
-            ATTRIBUTES_TO_COPY
-                .iter()
-                .any(|attr_whitelisted| attr.path.is_ident(attr_whitelisted))
-        });
+        // Don't copy across the "strum" meta attribute. Only passthrough the whitelisted
+        // attributes and proxy `#[strum_discriminants(...)]` attributes
+        let attrs = variant
+            .attrs
+            .iter()
+            .filter(|attr| {
+                ATTRIBUTES_TO_COPY
+                    .iter()
+                    .any(|attr_whitelisted| attr.path.is_ident(attr_whitelisted))
+            })
+            .map(|attr| {
+                if attr.path.is_ident("strum_discriminants") {
+                    let passthrough_group = attr
+                        .tokens
+                        .clone()
+                        .into_iter()
+                        .next()
+                        .ok_or_else(|| strum_discriminants_passthrough_error(attr))?;
+                    let passthrough_attribute = match passthrough_group {
+                        TokenTree::Group(ref group) => group.stream(),
+                        _ => {
+                            return Err(strum_discriminants_passthrough_error(passthrough_group));
+                        }
+                    };
+                    if passthrough_attribute.is_empty() {
+                        return Err(strum_discriminants_passthrough_error(passthrough_group));
+                    }
+                    Ok(quote! { #[#passthrough_attribute] })
+                } else {
+                    Ok(attr.to_token_stream())
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         discriminants.push(quote! { #(#attrs)* #ident });
     }

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -1,5 +1,5 @@
 use enum_variant_type::EnumVariantType;
-use strum::{Display, EnumDiscriminants, EnumIter, EnumString, IntoEnumIterator};
+use strum::{Display, EnumDiscriminants, EnumIter, EnumMessage, EnumString, IntoEnumIterator};
 
 #[allow(dead_code)]
 #[derive(Debug, Eq, PartialEq, EnumDiscriminants)]
@@ -80,6 +80,28 @@ enum WithDefault {
 #[test]
 fn with_default_test() {
     assert!(WithDefaultDiscriminants::A != WithDefaultDiscriminants::B);
+}
+
+// This test exists to ensure that we can pass attributes to the discriminant variants.
+#[allow(dead_code)]
+#[derive(Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumMessage))]
+enum WithPassthroughAttributes {
+    #[strum_discriminants(strum(message = "AAA"))]
+    A(String),
+    B,
+}
+
+#[test]
+fn with_passthrough_attributes_test() {
+    assert_eq!(
+        WithPassthroughAttributesDiscriminants::A.get_message(),
+        Some("AAA")
+    );
+    assert_eq!(
+        WithPassthroughAttributesDiscriminants::B.get_message(),
+        None
+    );
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
The use-cases:

* I wanted to combine `EnumMessage` with `EnumDiscriminants` and found that not all the attributes are passed
* `#[serde]` attributes on discriminant variants could also be useful