### PR TITLE
enum messages: Make the returned values all 'static

### DIFF
--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -118,9 +118,9 @@ pub trait IntoEnumIterator: Sized {
 /// assert_eq!("I have a dog", my_pet.get_message().unwrap());
 /// ```
 pub trait EnumMessage {
-    fn get_message(&self) -> Option<&str>;
-    fn get_detailed_message(&self) -> Option<&str>;
-    fn get_serializations(&self) -> &[&str];
+    fn get_message(&self) -> Option<&'static str>;
+    fn get_detailed_message(&self) -> Option<&'static str>;
+    fn get_serializations(&self) -> &'static [&'static str];
 }
 
 /// EnumProperty is a trait that makes it possible to store additional information

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -396,7 +396,7 @@ pub fn enum_iter(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// // Generated code looks like more or less like this:
 /// /*
 /// impl ::strum::EnumMessage for Color {
-///     fn get_message(&self) -> ::std::option::Option<&str> {
+///     fn get_message(&self) -> ::std::option::Option<&'static str> {
 ///         match self {
 ///             &Color::Red => ::std::option::Option::Some("Red"),
 ///             &Color::Green {..} => ::std::option::Option::Some("Simply Green"),
@@ -404,7 +404,7 @@ pub fn enum_iter(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///         }
 ///     }
 ///
-///     fn get_detailed_message(&self) -> ::std::option::Option<&str> {
+///     fn get_detailed_message(&self) -> ::std::option::Option<&'static str> {
 ///         match self {
 ///             &Color::Red => ::std::option::Option::Some("This is very red"),
 ///             &Color::Green {..}=> ::std::option::Option::Some("Simply Green"),
@@ -412,7 +412,7 @@ pub fn enum_iter(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///         }
 ///     }
 ///
-///     fn get_serializations(&self) -> &[&str] {
+///     fn get_serializations(&self) -> &'static [&'static str] {
 ///         match self {
 ///             &Color::Red => {
 ///                 static ARR: [&'static str; 1] = ["Red"];

--- a/strum_macros/src/macros/enum_messages.rs
+++ b/strum_macros/src/macros/enum_messages.rs
@@ -80,19 +80,19 @@ pub fn enum_message_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         impl #impl_generics ::strum::EnumMessage for #name #ty_generics #where_clause {
-            fn get_message(&self) -> ::core::option::Option<&str> {
+            fn get_message(&self) -> ::core::option::Option<&'static str> {
                 match self {
                     #(#arms),*
                 }
             }
 
-            fn get_detailed_message(&self) -> ::core::option::Option<&str> {
+            fn get_detailed_message(&self) -> ::core::option::Option<&'static str> {
                 match self {
                     #(#detailed_arms),*
                 }
             }
 
-            fn get_serializations(&self) -> &[&str] {
+            fn get_serializations(&self) -> &'static [&'static str] {
                 match self {
                     #(#serializations),*
                 }


### PR DESCRIPTION
This is (at least in theory) a breaking change, because someone might
have implemented this trait by hand, and their implementation won't
be declared as returning 'static lifetimes.

Closes #159