### PR TITLE
Replace enum_name with `Self`

### DIFF
--- a/strum_macros/src/macros/strings/from_string.rs
+++ b/strum_macros/src/macros/strings/from_string.rs
@@ -87,6 +87,7 @@ pub fn from_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     arms.push(default);
 
     Ok(quote! {
+        #[allow(clippy::use_self)]
         impl #impl_generics ::std::str::FromStr for #name #ty_generics #where_clause {
             type Err = ::strum::ParseError;
             fn from_str(s: &str) -> ::std::result::Result< #name #ty_generics , Self::Err> {

--- a/strum_macros/src/macros/strings/to_string.rs
+++ b/strum_macros/src/macros/strings/to_string.rs
@@ -40,6 +40,7 @@ pub fn to_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     }
 
     Ok(quote! {
+        #[allow(clippy::use_self)]
         impl #impl_generics ::std::string::ToString for #name #ty_generics #where_clause {
             fn to_string(&self) -> ::std::string::String {
                 match *self {


### PR DESCRIPTION
As it is possible to use constant `Self` instead of the structname
it is less complicated to use `Self`. Using the struct name even
generates warnings on strict warnin-settings.