### PR TITLE
Use proper minimum syn version

### DIFF
--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -22,7 +22,7 @@ name = "strum_macros"
 heck = "0.3"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["parsing", "extra-traits"] }
+syn = { version = "1.0.61", features = ["parsing", "extra-traits"] }
 
 [dev-dependencies]
 strum = "0.20"


### PR DESCRIPTION
RE: https://github.com/Peternator7/strum/pull/164

The correct way to fix this is to specify that you need this minimum syn version in this crate. https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html . In strum-macro's Cargo.toml change it to 

```toml
syn = { version = "1.0.61", features = ["parsing", "extra-traits"] }
```

serde_derive is not actually forcing an old version. It accepts any version >= 1.0 https://github.com/serde-rs/serde/blob/985725f820a08fbe1c23688422d79200d24502ec/serde_derive/Cargo.toml#L28 .

What probably happened is that in @hlmtre 's project the Cargo.lock file contained the older version and since strum doesn't spewcify which version is needed Cargo kept the older one.. To fix this locally before this proper fix is in you could have run `cargo update`.