### PR TITLE
Fix for Syn version spec ("1.0" → "1.0.61")

### DIFF
--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -22,7 +22,7 @@ name = "strum_macros"
 heck = "0.3"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["parsing", "extra-traits"] }
+syn = { version = "1.0.61", features = ["parsing", "extra-traits"] }
 
 [dev-dependencies]
 strum = "0.20"


### PR DESCRIPTION
The dependency build of `strum_macros` [fails](https://github.com/Tamschi/reserde/pull/8/checks?check_run_id=3342430840) in my project after `cargo +nightly update -Z minimal-versions`:

```
   Compiling syn v1.0.60
   […]
   Compiling strum_macros v0.21.0
error[E0599]: no method named `value` found for struct `LitBool` in the current scope
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/strum_macros-0.21.0/src/helpers/metadata.rs:197:43
    |
197 |                 input.parse::<LitBool>()?.value()
    |                                           ^^^^^-- help: remove the arguments
    |                                           |
    |                                           field, not a method

For more information about this error, try `rustc --explain E0599`.
error: could not compile `strum_macros` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```

This is due to the `syn = { version = "1.0", features = ["parsing", "extra-traits"] }` dependency [in `strum_macros/Cargo.toml`](https://github.com/Peternator7/strum/blob/master/strum_macros/Cargo.toml#L25), which isn't quite specific enough in this case as Syn doesn't follow Semver and regularly has features added in patch versions.

`LitBool.value()` was added in `syn@1.0.61`: `https://github.com/dtolnay/syn/compare/1.0.60...1.0.61#diff-ce4e3f87da05491a74818b9736b02d9c40274befb1e2c13f44c6995eb001b925R513-R515`
(Apologies, GitHub refuses to parse that link correctly.)

I've confirmed locally that version 1.0.61 is enough to fix my build.