### PR TITLE
Add EnumDiscriminants trait and provide for deriving it

### DIFF
--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -182,6 +182,12 @@ pub trait EnumCount {
     const COUNT: usize;
 }
 
+pub trait EnumDiscriminants {
+    type Discriminants;
+
+    fn discriminants(&self) -> Self::Discriminants;
+}
+
 /// A trait for retrieving the names of each variant in Enum. This trait can
 /// be autoderived by `strum_macros`.
 pub trait VariantNames {

--- a/strum_macros/src/macros/enum_discriminants.rs
+++ b/strum_macros/src/macros/enum_discriminants.rs
@@ -152,6 +152,20 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
     };
+    let impl_discriminants = {
+        let type_properties = ast.get_type_properties()?;
+        let strum_module_path = type_properties.crate_module_path();
+
+        quote! {
+            impl #impl_generics #strum_module_path::EnumDiscriminants for #name #ty_generics #where_clause {
+                type Discriminants = #discriminants_name;
+
+                fn discriminants(&self) -> Self::Discriminants {
+                    <Self::Discriminants as ::core::convert::From<&Self>>::from(self)
+                }
+            }
+        }
+    };
 
     Ok(quote! {
         /// Auto-generated discriminant enum variants
@@ -163,5 +177,6 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
         #impl_from
         #impl_from_ref
+        #impl_discriminants
     })
 }


### PR DESCRIPTION
This PR adds the following trait to strum:

```rust
pub trait EnumDiscriminants {
    type Discriminant;

    fn discriminants(&self) -> Self::Discriminants;
}
```

It also causes `derive(EnumDiscriminants)` to generate an implementation of this trait, e.g.

```rust
#[derive(strum::EnumDiscriminants)]
enum E {
    X,
    Y(i32),
    Z(String),
}
```

generates (in addition to what it generated before) this impl:

```rust
impl EnumDiscriminants for E {
    type Discriminants = EDiscriminants; // (the type generated by the derive macro)

    fn discriminants(&self) -> Self::Discriminants {
        // actual generated impl uses fully qualified syntax
        self.into()
    }
}
```

I'm happy to write tests/documentation for this addition, but before I do, is this something you'd be interested in adding?