### PR TITLE
Disambiguate associated items in trait impls

### DIFF
--- a/strum_macros/src/macros/enum_iter.rs
+++ b/strum_macros/src/macros/enum_iter.rs
@@ -96,7 +96,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         impl #impl_generics Iterator for #iter_name #ty_generics #where_clause {
             type Item = #name #ty_generics;
 
-            fn next(&mut self) -> Option<Self::Item> {
+            fn next(&mut self) -> Option<<Self as Iterator>::Item> {
                 self.nth(0)
             }
 
@@ -105,7 +105,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                 (t, Some(t))
             }
 
-            fn nth(&mut self, n: usize) -> Option<Self::Item> {
+            fn nth(&mut self, n: usize) -> Option<<Self as Iterator>::Item> {
                 let idx = self.idx + n + 1;
                 if idx + self.back_idx > #variant_count {
                     // We went past the end of the iterator. Freeze idx at #variant_count
@@ -127,7 +127,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         }
 
         impl #impl_generics DoubleEndedIterator for #iter_name #ty_generics #where_clause {
-            fn next_back(&mut self) -> Option<Self::Item> {
+            fn next_back(&mut self) -> Option<<Self as Iterator>::Item> {
                 let back_idx = self.back_idx + 1;
 
                 if self.idx + back_idx > #variant_count {

--- a/strum_macros/src/macros/strings/from_string.rs
+++ b/strum_macros/src/macros/strings/from_string.rs
@@ -91,7 +91,7 @@ pub fn from_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         #[allow(clippy::use_self)]
         impl #impl_generics ::core::str::FromStr for #name #ty_generics #where_clause {
             type Err = #strum_module_path::ParseError;
-            fn from_str(s: &str) -> ::core::result::Result< #name #ty_generics , Self::Err> {
+            fn from_str(s: &str) -> ::core::result::Result< #name #ty_generics , <Self as ::core::str::FromStr>::Err> {
                 match s {
                     #(#arms),*
                 }
@@ -136,7 +136,7 @@ fn try_from_str(
         #[allow(clippy::use_self)]
         impl #impl_generics ::core::convert::TryFrom<&str> for #name #ty_generics #where_clause {
             type Error = #strum_module_path::ParseError;
-            fn try_from(s: &str) -> ::core::result::Result< #name #ty_generics , Self::Error> {
+            fn try_from(s: &str) -> ::core::result::Result< #name #ty_generics , <Self as ::core::convert::TryFrom<&str>>::Error> {
                 ::core::str::FromStr::from_str(s)
             }
         }


### PR DESCRIPTION
The addition of `TryFrom<&str>` for `EnumString` breaks for enums that have
a variant called "Error". Rewrite as `<Self as Trait>` where associated
types are used as the return type for trait functions.

Example:

```rust
#[derive(EnumString)]
pub enum Test {
    Error,
}
```

error: ambiguous associated item
   --> src/lib.rs:3:10
    |
3   | #[derive(EnumString)]
    |          ^^^^^^^^^^
    |
    = note: `#[deny(ambiguous_associated_items)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>