### PR TITLE
Add doc comment to FromRepr

### DIFF
--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -128,6 +128,7 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         impl #impl_generics #name #ty_generics #where_clause {
+            #[doc = "Try to create [Self] from the raw representation"]
             #vis #const_if_possible fn from_repr(discriminant: #discriminant_type) -> Option<#name #ty_generics> {
                 #(#constant_defs)*
                 match discriminant {


### PR DESCRIPTION
Currently when deriving FromRepr for an enum with `#![deny(missing_docs)]` will cause errors.
This change would simple add a doc comment to the generated from_repr function to avoid the error.
An alternative I considered would be to just add `#[allow(missing_docs)]`.