### PR TITLE
minimal extraction of enum_metadata from PR #207.

### DIFF
--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -30,6 +30,8 @@
 // only for documentation purposes
 pub mod additional_attributes;
 
+use core::ops;
+
 /// The ParseError enum is a collection of all the possible reasons
 /// an enum can fail to parse from a string.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -190,6 +192,39 @@ pub trait VariantNames {
     const VARIANTS: &'static [&'static str];
 }
 
+pub trait EnumMetadata {
+    /// The repr type as a trait associated type.
+    type Repr: Copy
+        + ops::BitOr
+        + ops::BitAnd
+        + ops::BitXor
+        + ops::Shr
+        + ops::Shl
+        + ops::Not
+        + ops::BitOrAssign
+        + ops::BitAndAssign
+        + ops::BitXorAssign
+        + ops::ShrAssign
+        + ops::ShlAssign
+        + core::fmt::Debug;
+
+    /// The enum type, generally Self unless deriving EnumMetadata for a type which returns
+    /// metadata for another enum.
+    type EnumT: EnumMetadata;
+
+    /// Variant names
+    const VARIANTS: &'static [&'static str];
+    /// Number of variants
+    const COUNT: usize;
+    /// std::mem::size_of<Self::Repr>().
+    const REPR_SIZE: usize;
+
+    /// convert to the enums #[repr(..)] equivalent to `self as ..`
+    fn to_repr(self) -> Self::Repr;
+    /// Trait equivalent of EnumT::from_repr(...)
+    fn from_repr(repr: Self::Repr) -> Option<Self::EnumT>;
+}
+
 #[cfg(feature = "derive")]
 pub use strum_macros::*;
 
@@ -214,6 +249,7 @@ DocumentMacroRexports! {
     EnumCount,
     EnumDiscriminants,
     EnumIter,
+    EnumMetadata,
     EnumMessage,
     EnumProperty,
     EnumString,

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -206,6 +206,11 @@ pub trait EnumMetadata {
         + ops::BitXorAssign
         + ops::ShrAssign
         + ops::ShlAssign
+        + core::cmp::Eq
+        + core::cmp::Ord
+        + core::cmp::PartialEq
+        + core::cmp::PartialOrd
+        + core::fmt::Display
         + core::fmt::Debug;
 
     /// The enum type, generally Self unless deriving EnumMetadata for a type which returns

--- a/strum_macros/src/helpers/metadata_impl.rs
+++ b/strum_macros/src/helpers/metadata_impl.rs
@@ -1,0 +1,185 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Data, DeriveInput, PathArguments, Type, TypeParen};
+
+use crate::helpers::{non_enum_error, HasStrumVariantProperties, HasTypeProperties};
+
+pub struct MetadataImpl<'a> {
+    ast: &'a syn::DeriveInput,
+    gen_names: Option<Vec<syn::LitStr>>,
+    gen_from_repr: Option<FromReprTokens>,
+    pub enum_count: usize,
+    pub has_additional_data: bool,
+}
+
+pub struct FromReprTokens {
+    pub constant_defs: Vec<TokenStream>,
+    pub match_arms: Vec<TokenStream>,
+}
+
+impl<'a> MetadataImpl<'a> {
+    pub fn new(ast: &'a DeriveInput) -> Self {
+        MetadataImpl {
+            ast,
+            enum_count: 0,
+            gen_names: None,
+            gen_from_repr: None,
+            has_additional_data: false,
+        }
+    }
+
+    pub fn use_name_info(mut self) -> Self {
+        self.gen_names = Some(Vec::new());
+        self
+    }
+
+    pub fn use_from_repr(mut self) -> Self {
+        self.gen_from_repr = Some(FromReprTokens {
+            constant_defs: Vec::new(),
+            match_arms: Vec::new(),
+        });
+        self
+    }
+
+    pub fn discriminant_type(&self) -> Type {
+        let mut discriminant_type: Type = syn::parse("usize".parse().unwrap()).unwrap();
+        for attr in &self.ast.attrs {
+            let path = &attr.path;
+            let tokens = &attr.tokens;
+            if path.leading_colon.is_some() {
+                continue;
+            }
+            if path.segments.len() != 1 {
+                continue;
+            }
+            let segment = path.segments.first().unwrap();
+            if segment.ident != "repr" {
+                continue;
+            }
+            if segment.arguments != PathArguments::None {
+                continue;
+            }
+            let typ_paren = match syn::parse2::<Type>(tokens.clone()) {
+                Ok(Type::Paren(TypeParen { elem, .. })) => *elem,
+                _ => continue,
+            };
+            let inner_path = match &typ_paren {
+                Type::Path(t) => t,
+                _ => continue,
+            };
+            if let Some(seg) = inner_path.path.segments.last() {
+                for t in &[
+                    "u8", "u16", "u32", "u64", "usize", "i8", "i16", "i32", "i64", "isize",
+                ] {
+                    if seg.ident == t {
+                        discriminant_type = typ_paren;
+                        break;
+                    }
+                }
+            }
+        }
+        discriminant_type
+    }
+
+    fn params_from_fields(fields: &syn::Fields) -> (TokenStream, bool) {
+        use syn::Fields::*;
+        match &fields {
+            Unit => (quote! {}, false),
+            Unnamed(fields) => {
+                let defaults = ::std::iter::repeat(quote!(::core::default::Default::default()))
+                    .take(fields.unnamed.len());
+                (quote! { (#(#defaults),*) }, true)
+            }
+            Named(fields) => {
+                let fields = fields
+                    .named
+                    .iter()
+                    .map(|field| field.ident.as_ref().unwrap());
+                (
+                    quote! { {#(#fields: ::core::default::Default::default()),*} },
+                    true,
+                )
+            }
+        }
+    }
+
+    fn case_style(&self) -> Option<crate::helpers::case_style::CaseStyle> {
+        if let Ok(props) = self.ast.get_type_properties() {
+            props.case_style
+        } else {
+            None
+        }
+    }
+
+    pub fn generate(&mut self) -> syn::Result<()> {
+        let name = &self.ast.ident;
+        let discriminant_type = self.discriminant_type();
+
+        let case_style = self.case_style();
+        let mut prev_const_var_ident = None;
+        let variants = match &self.ast.data {
+            Data::Enum(v) => &v.variants,
+            _ => return Err(non_enum_error()),
+        };
+        self.enum_count = variants.len();
+        for variant in variants {
+            let props = variant.get_variant_properties()?;
+
+            if let Some(variant_names) = &mut self.gen_names {
+                variant_names.push(props.get_preferred_name(case_style));
+            }
+
+            if let Some(FromReprTokens {
+                match_arms,
+                constant_defs,
+            }) = &mut self.gen_from_repr
+            {
+                if props.disabled.is_some() {
+                    continue;
+                }
+
+                let ident = &variant.ident;
+                let (params, has_additional_data) = Self::params_from_fields(&variant.fields);
+                if has_additional_data {
+                    self.has_additional_data = has_additional_data;
+                }
+
+                let const_var_ident = {
+                    use heck::ToShoutySnakeCase;
+                    let const_var_str = format!("{}_DISCRIMINANT", ident).to_shouty_snake_case();
+                    format_ident!("{}", const_var_str)
+                };
+
+                let const_val_expr = match &variant.discriminant {
+                    Some((_, expr)) => quote! { #expr },
+                    None => match &prev_const_var_ident {
+                        Some(prev) => quote! { #prev + 1 },
+                        None => quote! { 0 },
+                    },
+                };
+
+                constant_defs
+                    .push(quote! {const #const_var_ident: #discriminant_type = #const_val_expr;});
+                match_arms.push(quote! {v if v == #const_var_ident => ::core::option::Option::Some(#name::#ident #params)});
+                prev_const_var_ident = Some(const_var_ident);
+            }
+        }
+        if let Some(FromReprTokens { match_arms, .. }) = &mut self.gen_from_repr {
+            match_arms.push(quote! { _ => ::core::option::Option::None });
+        }
+
+        Ok(())
+    }
+
+    pub fn variant_names(&self) -> &Option<Vec<syn::LitStr>> {
+        &self.gen_names
+    }
+
+    pub fn from_repr(&self) -> &Option<FromReprTokens> {
+        &self.gen_from_repr
+    }
+
+    pub fn enum_count(&self) -> usize {
+        self.enum_count
+    }
+}

--- a/strum_macros/src/helpers/mod.rs
+++ b/strum_macros/src/helpers/mod.rs
@@ -4,6 +4,7 @@ pub use self::variant_props::HasStrumVariantProperties;
 
 pub mod case_style;
 mod metadata;
+pub mod metadata_impl;
 pub mod type_props;
 pub mod variant_props;
 

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -466,6 +466,17 @@ pub fn from_repr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     toks.into()
 }
 
+/// Enum Metadata documentation.
+#[proc_macro_derive(EnumMetadata, attributes(strum))]
+pub fn enum_metadata(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = syn::parse_macro_input!(input as DeriveInput);
+
+    let toks = macros::enum_metadata::enum_metadata_inner(&ast)
+        .unwrap_or_else(|err| err.to_compile_error());
+    debug_print_generated(&ast, &toks);
+    toks.into()
+}
+
 /// Add a verbose message to an enum variant.
 ///
 /// Encode strings into the enum itself. The `strum_macros::EmumMessage` macro implements the `strum::EnumMessage` trait.

--- a/strum_macros/src/macros/enum_count.rs
+++ b/strum_macros/src/macros/enum_count.rs
@@ -1,14 +1,12 @@
+use crate::helpers::metadata_impl::MetadataImpl;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput};
+use syn::DeriveInput;
 
-use crate::helpers::{non_enum_error, HasTypeProperties};
+use crate::helpers::HasTypeProperties;
 
 pub(crate) fn enum_count_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
-    let n = match &ast.data {
-        Data::Enum(v) => v.variants.len(),
-        _ => return Err(non_enum_error()),
-    };
+    let n = MetadataImpl::new(ast)?.enum_count;
     let type_properties = ast.get_type_properties()?;
     let strum_module_path = type_properties.crate_module_path();
 

--- a/strum_macros/src/macros/enum_metadata.rs
+++ b/strum_macros/src/macros/enum_metadata.rs
@@ -5,7 +5,7 @@ use syn::DeriveInput;
 
 pub fn enum_metadata_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
-    let mut metadata = MetadataImpl::new(ast)?.use_name_info().use_from_repr();
+    let mut metadata = MetadataImpl::new(ast)?.use_name_info().use_from_repr()?;
     let discriminant_type = metadata.discriminant_type();
     metadata.generate()?;
     let enum_count = metadata.enum_count();

--- a/strum_macros/src/macros/enum_metadata.rs
+++ b/strum_macros/src/macros/enum_metadata.rs
@@ -1,51 +1,13 @@
+use crate::helpers::metadata_impl::{FromReprTokens, MetadataImpl};
+use crate::helpers::non_enum_error;
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote};
-use syn::{Data, DeriveInput, PathArguments, Type, TypeParen};
-
-use crate::helpers::{non_enum_error, HasStrumVariantProperties, HasTypeProperties};
+use quote::quote;
+use syn::{Data, DeriveInput};
 
 pub fn enum_metadata_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
     let gen = &ast.generics;
     let (impl_generics, ty_generics, where_clause) = gen.split_for_impl();
-    let attrs = &ast.attrs;
-
-    let mut discriminant_type: Type = syn::parse("usize".parse().unwrap()).unwrap();
-    for attr in attrs {
-        let path = &attr.path;
-        let tokens = &attr.tokens;
-        if path.leading_colon.is_some() {
-            continue;
-        }
-        if path.segments.len() != 1 {
-            continue;
-        }
-        let segment = path.segments.first().unwrap();
-        if segment.ident != "repr" {
-            continue;
-        }
-        if segment.arguments != PathArguments::None {
-            continue;
-        }
-        let typ_paren = match syn::parse2::<Type>(tokens.clone()) {
-            Ok(Type::Paren(TypeParen { elem, .. })) => *elem,
-            _ => continue,
-        };
-        let inner_path = match &typ_paren {
-            Type::Path(t) => t,
-            _ => continue,
-        };
-        if let Some(seg) = inner_path.path.segments.last() {
-            for t in &[
-                "u8", "u16", "u32", "u64", "usize", "i8", "i16", "i32", "i64", "isize",
-            ] {
-                if seg.ident == t {
-                    discriminant_type = typ_paren;
-                    break;
-                }
-            }
-        }
-    }
 
     if gen.lifetimes().count() > 0 {
         return Err(syn::Error::new(
@@ -55,69 +17,21 @@ pub fn enum_metadata_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         ));
     }
 
-    let variants = match &ast.data {
-        Data::Enum(v) => &v.variants,
+    match &ast.data {
+        Data::Enum(_) => (),
         _ => return Err(non_enum_error()),
     };
 
-    let mut arms = Vec::new();
-    let mut constant_defs = Vec::new();
-    let mut prev_const_var_ident = None;
-    for variant in variants {
-        use syn::Fields::*;
+    let mut metadata = MetadataImpl::new(ast).use_name_info().use_from_repr();
+    let discriminant_type = metadata.discriminant_type();
+    metadata.generate()?;
+    let enum_count = metadata.enum_count();
+    let variant_names = metadata.variant_names().as_ref().unwrap();
 
-        if variant.get_variant_properties()?.disabled.is_some() {
-            continue;
-        }
-
-        let ident = &variant.ident;
-        let params = match &variant.fields {
-            Unit => quote! {},
-            Unnamed(fields) => {
-                let defaults = ::core::iter::repeat(quote!(::core::default::Default::default()))
-                    .take(fields.unnamed.len());
-                quote! { (#(#defaults),*) }
-            }
-            Named(fields) => {
-                let fields = fields
-                    .named
-                    .iter()
-                    .map(|field| field.ident.as_ref().unwrap());
-                quote! { {#(#fields: ::core::default::Default::default()),*} }
-            }
-        };
-
-        use heck::ToShoutySnakeCase;
-        let const_var_str = format!("{}_DISCRIMINANT", variant.ident).to_shouty_snake_case();
-        let const_var_ident = format_ident!("{}", const_var_str);
-
-        let const_val_expr = match &variant.discriminant {
-            Some((_, expr)) => quote! { #expr },
-            None => match &prev_const_var_ident {
-                Some(prev) => quote! { #prev + 1 },
-                None => quote! { 0 },
-            },
-        };
-
-        constant_defs.push(quote! {const #const_var_ident: #discriminant_type = #const_val_expr;});
-        arms.push(quote! {v if v == #const_var_ident => ::core::option::Option::Some(#name::#ident #params)});
-
-        prev_const_var_ident = Some(const_var_ident);
-    }
-
-    arms.push(quote! { _ => ::core::option::Option::None });
-
-    let type_properties = ast.get_type_properties()?;
-
-    let variant_names = variants
-        .iter()
-        .map(|v| {
-            let props = v.get_variant_properties()?;
-            Ok(props.get_preferred_name(type_properties.case_style))
-        })
-        .collect::<syn::Result<Vec<_>>>()?;
-
-    let enum_count = variants.len();
+    let FromReprTokens {
+        constant_defs,
+        match_arms,
+    } = &metadata.from_repr().as_ref().unwrap();
 
     Ok(quote! {
         impl #impl_generics EnumMetadata for #name #ty_generics #where_clause {
@@ -141,7 +55,7 @@ pub fn enum_metadata_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             fn from_repr(discriminant: #discriminant_type) -> Option<Self> {
                 #(#constant_defs)*
                 match discriminant {
-                    #(#arms),*
+                    #(#match_arms),*
                 }
             }
         }

--- a/strum_macros/src/macros/enum_metadata.rs
+++ b/strum_macros/src/macros/enum_metadata.rs
@@ -74,7 +74,7 @@ pub fn enum_metadata_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         let params = match &variant.fields {
             Unit => quote! {},
             Unnamed(fields) => {
-                let defaults = ::std::iter::repeat(quote!(::core::default::Default::default()))
+                let defaults = ::core::iter::repeat(quote!(::core::default::Default::default()))
                     .take(fields.unnamed.len());
                 quote! { (#(#defaults),*) }
             }
@@ -128,7 +128,7 @@ pub fn enum_metadata_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
             const VARIANTS: &'static [&'static str] = &[ #(#variant_names),* ];
             const COUNT: usize = #enum_count;
-            const REPR_SIZE: usize = std::mem::size_of::<Self::Repr>();
+            const REPR_SIZE: usize = ::core::mem::size_of::<Self::Repr>();
 
             fn to_repr(self) -> #discriminant_type {
                self as #discriminant_type

--- a/strum_macros/src/macros/enum_variant_names.rs
+++ b/strum_macros/src/macros/enum_variant_names.rs
@@ -1,34 +1,23 @@
+use crate::helpers::metadata_impl::MetadataImpl;
+use crate::helpers::HasTypeProperties;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput};
-
-use crate::helpers::{non_enum_error, HasStrumVariantProperties, HasTypeProperties};
+use syn::DeriveInput;
 
 pub fn enum_variant_names_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
-    let gen = &ast.generics;
-    let (impl_generics, ty_generics, where_clause) = gen.split_for_impl();
-
-    let variants = match &ast.data {
-        Data::Enum(v) => &v.variants,
-        _ => return Err(non_enum_error()),
-    };
+    let mut metadata = MetadataImpl::new(ast)?.use_name_info();
+    metadata.generate()?;
+    let variant_names = metadata.variant_names().as_ref().unwrap();
+    let (impl_generics, ty_generics, where_clause) = &metadata.generics_split();
 
     // Derives for the generated enum
     let type_properties = ast.get_type_properties()?;
     let strum_module_path = type_properties.crate_module_path();
 
-    let names = variants
-        .iter()
-        .map(|v| {
-            let props = v.get_variant_properties()?;
-            Ok(props.get_preferred_name(type_properties.case_style))
-        })
-        .collect::<syn::Result<Vec<_>>>()?;
-
     Ok(quote! {
         impl #impl_generics #strum_module_path::VariantNames for #name #ty_generics #where_clause {
-            const VARIANTS: &'static [&'static str] = &[ #(#names),* ];
+            const VARIANTS: &'static [&'static str] = &[ #(#variant_names),* ];
         }
     })
 }

--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -8,7 +8,7 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
     let vis = &ast.vis;
 
-    let mut metadata = MetadataImpl::new(ast)?.use_from_repr();
+    let mut metadata = MetadataImpl::new(ast)?.use_from_repr()?;
 
     let discriminant_type = metadata.discriminant_type();
     metadata.generate()?;

--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -1,52 +1,14 @@
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote};
-use syn::{Data, DeriveInput, PathArguments, Type, TypeParen};
+use quote::quote;
+use syn::DeriveInput;
 
-use crate::helpers::{non_enum_error, HasStrumVariantProperties};
+use crate::helpers::metadata_impl::{FromReprTokens, MetadataImpl};
 
 pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
     let gen = &ast.generics;
     let (impl_generics, ty_generics, where_clause) = gen.split_for_impl();
     let vis = &ast.vis;
-    let attrs = &ast.attrs;
-
-    let mut discriminant_type: Type = syn::parse("usize".parse().unwrap()).unwrap();
-    for attr in attrs {
-        let path = &attr.path;
-        let tokens = &attr.tokens;
-        if path.leading_colon.is_some() {
-            continue;
-        }
-        if path.segments.len() != 1 {
-            continue;
-        }
-        let segment = path.segments.first().unwrap();
-        if segment.ident != "repr" {
-            continue;
-        }
-        if segment.arguments != PathArguments::None {
-            continue;
-        }
-        let typ_paren = match syn::parse2::<Type>(tokens.clone()) {
-            Ok(Type::Paren(TypeParen { elem, .. })) => *elem,
-            _ => continue,
-        };
-        let inner_path = match &typ_paren {
-            Type::Path(t) => t,
-            _ => continue,
-        };
-        if let Some(seg) = inner_path.path.segments.last() {
-            for t in &[
-                "u8", "u16", "u32", "u64", "usize", "i8", "i16", "i32", "i64", "isize",
-            ] {
-                if seg.ident == t {
-                    discriminant_type = typ_paren;
-                    break;
-                }
-            }
-        }
-    }
 
     if gen.lifetimes().count() > 0 {
         return Err(syn::Error::new(
@@ -56,62 +18,15 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         ));
     }
 
-    let variants = match &ast.data {
-        Data::Enum(v) => &v.variants,
-        _ => return Err(non_enum_error()),
-    };
+    let mut metadata = MetadataImpl::new(ast).use_from_repr();
+    let discriminant_type = metadata.discriminant_type();
+    metadata.generate()?;
+    let FromReprTokens {
+        constant_defs,
+        match_arms,
+    } = &metadata.from_repr().as_ref().unwrap();
 
-    let mut arms = Vec::new();
-    let mut constant_defs = Vec::new();
-    let mut has_additional_data = false;
-    let mut prev_const_var_ident = None;
-    for variant in variants {
-        use syn::Fields::*;
-
-        if variant.get_variant_properties()?.disabled.is_some() {
-            continue;
-        }
-
-        let ident = &variant.ident;
-        let params = match &variant.fields {
-            Unit => quote! {},
-            Unnamed(fields) => {
-                has_additional_data = true;
-                let defaults = ::std::iter::repeat(quote!(::core::default::Default::default()))
-                    .take(fields.unnamed.len());
-                quote! { (#(#defaults),*) }
-            }
-            Named(fields) => {
-                has_additional_data = true;
-                let fields = fields
-                    .named
-                    .iter()
-                    .map(|field| field.ident.as_ref().unwrap());
-                quote! { {#(#fields: ::core::default::Default::default()),*} }
-            }
-        };
-
-        use heck::ToShoutySnakeCase;
-        let const_var_str = format!("{}_DISCRIMINANT", variant.ident).to_shouty_snake_case();
-        let const_var_ident = format_ident!("{}", const_var_str);
-
-        let const_val_expr = match &variant.discriminant {
-            Some((_, expr)) => quote! { #expr },
-            None => match &prev_const_var_ident {
-                Some(prev) => quote! { #prev + 1 },
-                None => quote! { 0 },
-            },
-        };
-
-        constant_defs.push(quote! {const #const_var_ident: #discriminant_type = #const_val_expr;});
-        arms.push(quote! {v if v == #const_var_ident => ::core::option::Option::Some(#name::#ident #params)});
-
-        prev_const_var_ident = Some(const_var_ident);
-    }
-
-    arms.push(quote! { _ => ::core::option::Option::None });
-
-    let const_if_possible = if has_additional_data {
+    let const_if_possible = if metadata.has_additional_data {
         quote! {}
     } else {
         #[rustversion::before(1.46)]
@@ -126,17 +41,13 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         filter_by_rust_version(quote! { const })
     };
 
-    // Note: synchronize changes with `EnumMetadata::from_repr`,
-    // it duplicates this logic in an inherent impl.
-    // Making it possible to have both impls on the same type;
-    // so their behavior must be kept the same.
     Ok(quote! {
         impl #impl_generics #name #ty_generics #where_clause {
             #[doc = "Try to create [Self] from the raw representation"]
             #vis #const_if_possible fn from_repr(discriminant: #discriminant_type) -> Option<#name #ty_generics> {
                 #(#constant_defs)*
                 match discriminant {
-                    #(#arms),*
+                    #(#match_arms),*
                 }
             }
         }

--- a/strum_macros/src/macros/mod.rs
+++ b/strum_macros/src/macros/mod.rs
@@ -2,6 +2,7 @@ pub mod enum_count;
 pub mod enum_discriminants;
 pub mod enum_iter;
 pub mod enum_messages;
+pub mod enum_metadata;
 pub mod enum_properties;
 pub mod enum_variant_names;
 pub mod from_repr;

--- a/strum_tests/tests/enum_count.rs
+++ b/strum_tests/tests/enum_count.rs
@@ -40,3 +40,15 @@ fn crate_module_path_test() {
     assert_eq!(7, Week::COUNT);
     assert_eq!(Week::iter().count(), Week::COUNT);
 }
+
+// EnumIter doesn't support lifetimes so we can't check consistency with that.
+#[derive(Debug, EnumCount)]
+enum HasLifetime<'a> {
+    Hello(&'a str),
+}
+
+#[test]
+fn lifetime_test() {
+    let _ = HasLifetime::Hello("world");
+    assert_eq!(1, HasLifetime::COUNT);
+}

--- a/strum_tests/tests/enum_metadata.rs
+++ b/strum_tests/tests/enum_metadata.rs
@@ -1,7 +1,6 @@
 use strum::EnumMetadata;
 // To check that from_repr impls on both the enum type,
 // and EnumMetadata don't clash in any way.
-use core::ops;
 use strum::FromRepr;
 
 #[derive(Debug, Eq, PartialEq, EnumMetadata, FromRepr)]

--- a/strum_tests/tests/enum_metadata.rs
+++ b/strum_tests/tests/enum_metadata.rs
@@ -1,0 +1,31 @@
+use strum::EnumMetadata;
+// To check that from_repr impls on both the enum type,
+// and EnumMetadata don't clash in any way.
+use core::ops;
+use strum::FromRepr;
+
+#[derive(Debug, Eq, PartialEq, EnumMetadata, FromRepr)]
+#[repr(u8)]
+enum ABC {
+    A = 1 << 0,
+    B = 1 << 1,
+    C = 1 << 2,
+}
+
+#[test]
+fn abc_variant_names() {
+    assert_eq!(ABC::VARIANTS, ["A", "B", "C"]);
+}
+
+#[test]
+fn abc_variant_count() {
+    assert_eq!(ABC::COUNT, 3);
+}
+
+#[test]
+fn abc_from_repr_same() {
+    assert_eq!(
+        ABC::from_repr(ABC::A as u8),
+        <ABC as EnumMetadata>::from_repr(ABC::A.to_repr())
+    )
+}

--- a/strum_tests/tests/enum_variant_names.rs
+++ b/strum_tests/tests/enum_variant_names.rs
@@ -126,3 +126,15 @@ fn crate_module_path_test() {
 
     assert_eq!(Color::VARIANTS, &["Red", "b", "y"]);
 }
+
+#[derive(Debug, EnumVariantNames)]
+enum HasLifetime<'a> {
+    #[strum(serialize = "hello")]
+    Hello(&'a str),
+}
+
+#[test]
+fn has_lifetime_variant_name() {
+    let _ = HasLifetime::Hello("world");
+    assert_eq!(HasLifetime::VARIANTS, &["hello"]);
+}


### PR DESCRIPTION
This is the minimal extraction of `EnumMetadata`, which excises `OpaqueRepr` from my pr #207.

It doesn't yet fix the duplicate code issue, I also think there is a function in #183 which this hadn't implemented.

I need to work on the other crate where the stuff which was excised goes however,
So If anyone wants to pick this up, by all means.

I assume what needs to be done is pull as much as we can out into `strum_macros/helpers/` and then call those from the various `..._inner(..)` calls.  Instead of just duplicating everything.  But note that the types and constness between the inherent and trait impl may differ making it difficult to remove all duplication.

Otherwise i'll try and get back to this when I can -- or we can close it and reopen at that time!