### PR TITLE
Add `allow(clippy::use_self)` to remove warnings from `FromRepr`

### DIFF
--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -127,6 +127,7 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     };
 
     Ok(quote! {
+        #[allow(clippy::use_self)]
         impl #impl_generics #name #ty_generics #where_clause {
             #[doc = "Try to create [Self] from the raw representation"]
             #vis #const_if_possible fn from_repr(discriminant: #discriminant_type) -> Option<#name #ty_generics> {


### PR DESCRIPTION
See #161 where this was done before.

Currently using the derive macro [`FromRepr`](https://docs.rs/strum_macros/0.23.1/strum_macros/derive.FromRepr.html) can trigger a warning, [`clippy::use_self`](https://rust-lang.github.io/rust-clippy/master/index.html#use_self), this PR prevents that.