### PR TITLE
Use full path for `None` in `EnumIter`

### DIFF
--- a/strum_macros/src/macros/enum_iter.rs
+++ b/strum_macros/src/macros/enum_iter.rs
@@ -110,7 +110,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                     // so that it doesn't overflow if the user calls this repeatedly.
                     // See PR #76 for context.
                     self.idx = #variant_count;
-                    None
+                    ::core::option::Option::None
                 } else {
                     self.idx = idx;
                     self.get(idx - 1)
@@ -133,7 +133,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                     // so that it doesn't overflow if the user calls this repeatedly.
                     // See PR #76 for context.
                     self.back_idx = #variant_count;
-                    None
+                    ::core::option::Option::None
                 } else {
                     self.back_idx = back_idx;
                     self.get(#variant_count - self.back_idx)


### PR DESCRIPTION
It was possible for a conflict with other `None` identities.

### Minimal Reproduction

```toml
[dependencies]
strum = { version = "0.24.0", features = ["derive"] }
```

```rust
use strum::EnumIter;
use Foo::*;

#[derive(EnumIter)]
enum Foo {
    None,
}
```