### PR TITLE
Revert "Add TryFrom to FromRepr (#217)"

### DIFF
--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -384,8 +384,7 @@ pub fn enum_iter(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     toks.into()
 }
 
-/// Add a function to enum that allows accessing variants by its discriminant.
-/// On Rust 1.34 and above, std::convert::TryFrom<TDiscriminant> will be derived as well.
+/// Add a function to enum that allows accessing variants by its discriminant
 ///
 /// This macro adds a standalone function to obtain an enum variant by its discriminant. The macro adds
 /// `from_repr(discriminant: usize) -> Option<YourEnum>` as a standalone function on the enum. For

--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{Data, DeriveInput, Fields, PathArguments, Type, TypeParen};
 
-use crate::helpers::{non_enum_error, HasStrumVariantProperties, HasTypeProperties};
+use crate::helpers::{non_enum_error, HasStrumVariantProperties};
 
 pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
@@ -11,9 +11,6 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let (impl_generics, ty_generics, where_clause) = gen.split_for_impl();
     let vis = &ast.vis;
     let attrs = &ast.attrs;
-
-    let type_properties = ast.get_type_properties()?;
-    let strum_module_path = type_properties.crate_module_path();
 
     let mut discriminant_type: Type = syn::parse("usize".parse().unwrap()).unwrap();
     for attr in attrs {
@@ -127,7 +124,7 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         filter_by_rust_version(quote! { const })
     };
 
-    let from_repr = quote! {
+    Ok(quote! {
         #[allow(clippy::use_self)]
         impl #impl_generics #name #ty_generics #where_clause {
             #[doc = "Try to create [Self] from the raw representation"]
@@ -138,51 +135,5 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                 }
             }
         }
-    };
-
-    let try_from_repr = try_from_repr(
-        name,
-        &discriminant_type,
-        &impl_generics,
-        &ty_generics,
-        where_clause,
-        &strum_module_path,
-    );
-
-    Ok(quote! {
-        #from_repr
-        #try_from_repr
     })
-}
-
-#[rustversion::before(1.34)]
-fn try_from_repr(
-    _name: &proc_macro2::Ident,
-    _discriminant_type: &Type,
-    _impl_generics: &syn::ImplGenerics,
-    _ty_generics: &syn::TypeGenerics,
-    _where_clause: Option<&syn::WhereClause>,
-    _strum_module_path: &syn::Path,
-) -> TokenStream {
-    Default::default()
-}
-
-#[rustversion::since(1.34)]
-fn try_from_repr(
-    name: &proc_macro2::Ident,
-    discriminant_type: &Type,
-    impl_generics: &syn::ImplGenerics,
-    ty_generics: &syn::TypeGenerics,
-    where_clause: Option<&syn::WhereClause>,
-    strum_module_path: &syn::Path,
-) -> TokenStream {
-    quote! {
-        #[allow(clippy::use_self)]
-        impl #impl_generics ::core::convert::TryFrom<#discriminant_type> for #name #ty_generics #where_clause {
-            type Error = #strum_module_path::ParseError;
-            fn try_from(s: #discriminant_type) -> ::core::result::Result< #name #ty_generics , <Self as ::core::convert::TryFrom<#discriminant_type>>::Error> {
-                Self::from_repr(s).ok_or(#strum_module_path::ParseError::VariantNotFound)
-            }
-        }
-    }
 }

--- a/strum_tests/Cargo.toml
+++ b/strum_tests/Cargo.toml
@@ -15,7 +15,6 @@ clap = "=2.33.0"
 enum_variant_type = "=0.2.0"
 structopt = "0.2.18"
 bitflags = "=1.2"
-if_rust_version = "1.0"
 
 [dev-dependencies]
 rustversion = "1.0"

--- a/strum_tests/tests/from_repr.rs
+++ b/strum_tests/tests/from_repr.rs
@@ -1,4 +1,3 @@
-use if_rust_version::if_rust_version;
 use strum::FromRepr;
 
 #[derive(Debug, FromRepr, PartialEq)]
@@ -13,31 +12,14 @@ enum Week {
     Saturday = 8,
 }
 
-macro_rules! assert_eq_repr {
-    ( $type:ident::from_repr($number:literal), Some($enum:expr) ) => {
-        assert_eq!($type::from_repr($number), Some($enum));
-        if_rust_version! { >= 1.34 {
-            assert_eq!(core::convert::TryInto::<$type>::try_into($number), Ok($enum));
-            assert_eq!(<$type as core::convert::TryFrom<_>>::try_from($number), Ok($enum));
-        }}
-    };
-    ( $type:ident::from_repr($number:literal), None ) => {
-        assert_eq!($type::from_repr($number), None);
-        if_rust_version! { >= 1.34 {
-            assert_eq!(core::convert::TryInto::<$type>::try_into($number), Err(::strum::ParseError::VariantNotFound));
-            assert_eq!(<$type as core::convert::TryFrom<_>>::try_from($number), Err(::strum::ParseError::VariantNotFound));
-        }}
-    };
-}
-
 #[test]
 fn simple_test() {
-    assert_eq_repr!(Week::from_repr(0), Some(Week::Sunday));
-    assert_eq_repr!(Week::from_repr(1), Some(Week::Monday));
-    assert_eq_repr!(Week::from_repr(6), None);
-    assert_eq_repr!(Week::from_repr(7), Some(Week::Friday));
-    assert_eq_repr!(Week::from_repr(8), Some(Week::Saturday));
-    assert_eq_repr!(Week::from_repr(9), None);
+    assert_eq!(Week::from_repr(0), Some(Week::Sunday));
+    assert_eq!(Week::from_repr(1), Some(Week::Monday));
+    assert_eq!(Week::from_repr(6), None);
+    assert_eq!(Week::from_repr(7), Some(Week::Friday));
+    assert_eq!(Week::from_repr(8), Some(Week::Saturday));
+    assert_eq!(Week::from_repr(9), None);
 }
 
 #[rustversion::since(1.46)]
@@ -75,7 +57,7 @@ fn crate_module_path_test() {
         Saturday,
     }
 
-    assert_eq_repr!(Week::from_repr(0), Some(Week::Sunday));
-    assert_eq_repr!(Week::from_repr(6), Some(Week::Saturday));
-    assert_eq_repr!(Week::from_repr(7), None);
+    assert_eq!(Week::from_repr(0), Some(Week::Sunday));
+    assert_eq!(Week::from_repr(6), Some(Week::Saturday));
+    assert_eq!(Week::from_repr(7), None);
 }


### PR DESCRIPTION
This reverts commit ac757fa9702cacd4559c444b309c27b97fa1de59.

Adding TryFrom to `FromRepr` and it was more problematic than I had originally thought for people who hit this issue to work around it. Reverting for now so that we can rethink how it should be implemented.