### PR TITLE
Fix camel_case to PascalCase bug

### DIFF
--- a/strum_macros/src/helpers/case_style.rs
+++ b/strum_macros/src/helpers/case_style.rs
@@ -57,12 +57,14 @@ impl FromStr for CaseStyle {
 
     fn from_str(text: &str) -> Result<Self, ()> {
         Ok(match text {
-            "camel_case" | "PascalCase" => CaseStyle::PascalCase,
+            // "camel_case" is a soft-deprecated case-style left for backward compatibility.
+            // <https://github.com/Peternator7/strum/pull/250#issuecomment-1374682221>
+            "PascalCase" | "camel_case" => CaseStyle::PascalCase,
             "camelCase" => CaseStyle::CamelCase,
             "snake_case" | "snek_case" => CaseStyle::SnakeCase,
-            "kebab_case" | "kebab-case" => CaseStyle::KebabCase,
+            "kebab-case" | "kebab_case" => CaseStyle::KebabCase,
             "SCREAMING-KEBAB-CASE" => CaseStyle::ScreamingKebabCase,
-            "shouty_snake_case" | "shouty_snek_case" | "SCREAMING_SNAKE_CASE" => {
+            "SCREAMING_SNAKE_CASE" | "shouty_snake_case" | "shouty_snek_case" => {
                 CaseStyle::ShoutySnakeCase
             }
             "title_case" => CaseStyle::TitleCase,
@@ -109,9 +111,45 @@ impl CaseStyleHelpers for Ident {
     }
 }
 
-#[test]
-fn test_convert_case() {
-    let id = Ident::new("test_me", proc_macro2::Span::call_site());
-    assert_eq!("testMe", id.convert_case(Some(CaseStyle::CamelCase)));
-    assert_eq!("TestMe", id.convert_case(Some(CaseStyle::PascalCase)));
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_case() {
+        let id = Ident::new("test_me", proc_macro2::Span::call_site());
+        assert_eq!("testMe", id.convert_case(Some(CaseStyle::CamelCase)));
+        assert_eq!("TestMe", id.convert_case(Some(CaseStyle::PascalCase)));
+    }
+
+    #[test]
+    fn test_impl_from_str_for_case_style_pascal_case() {
+        use CaseStyle::*;
+        let f = CaseStyle::from_str;
+
+        assert_eq!(PascalCase, f("PascalCase").unwrap());
+        assert_eq!(PascalCase, f("camel_case").unwrap());
+
+        assert_eq!(CamelCase, f("camelCase").unwrap());
+
+        assert_eq!(SnakeCase, f("snake_case").unwrap());
+        assert_eq!(SnakeCase, f("snek_case").unwrap());
+
+        assert_eq!(KebabCase, f("kebab-case").unwrap());
+        assert_eq!(KebabCase, f("kebab_case").unwrap());
+
+        assert_eq!(ScreamingKebabCase, f("SCREAMING-KEBAB-CASE").unwrap());
+
+        assert_eq!(ShoutySnakeCase, f("SCREAMING_SNAKE_CASE").unwrap());
+        assert_eq!(ShoutySnakeCase, f("shouty_snake_case").unwrap());
+        assert_eq!(ShoutySnakeCase, f("shouty_snek_case").unwrap());
+
+        assert_eq!(LowerCase, f("lowercase").unwrap());
+
+        assert_eq!(UpperCase, f("UPPERCASE").unwrap());
+
+        assert_eq!(TitleCase, f("title_case").unwrap());
+
+        assert_eq!(MixedCase, f("mixed_case").unwrap());
+    }
 }

--- a/strum_tests/tests/serialize_all.rs
+++ b/strum_tests/tests/serialize_all.rs
@@ -32,3 +32,30 @@ fn test_serialize_all_upper_case() {
     assert_eq!(Foo2::DarkBlack, Foo2::from_str("DARKBLACK").unwrap());
     assert_eq!("DARKBLACK", <&'static str>::from(Foo2::DarkBlack));
 }
+
+// This is a soft-deprecated behavior. Use `camelCase` instead.
+#[derive(Debug, Eq, PartialEq, EnumString, Display, IntoStaticStr)]
+#[strum(serialize_all = "camel_case")]
+enum Foo3 {
+    CamelCase,
+}
+
+#[test]
+fn test_serialize_all_written_in_snake_case_camel_case() {
+    assert_eq!("CamelCase", Foo3::CamelCase.to_string());
+    assert_eq!(Foo3::CamelCase, Foo3::from_str("CamelCase").unwrap());
+    assert_eq!("CamelCase", <&'static str>::from(Foo3::CamelCase));
+}
+
+#[derive(Debug, Eq, PartialEq, EnumString, Display, IntoStaticStr)]
+#[strum(serialize_all = "camelCase")]
+enum Foo4 {
+    CamelCase,
+}
+
+#[test]
+fn test_serialize_all_camel_case() {
+    assert_eq!("camelCase", Foo4::CamelCase.to_string());
+    assert_eq!(Foo4::CamelCase, Foo4::from_str("camelCase").unwrap());
+    assert_eq!("camelCase", <&'static str>::from(Foo4::CamelCase));
+}


### PR DESCRIPTION
Specifying camel_case for serialize_all will result in a PascalCase. Is this the intended behavior?

This pull request assumes that this is unintended behavior and fixes it.

---

This is not related to this pull request, but I have a point of concern. If you allow a snake_case specification for each variant, I would like to see it supported for all variants. Otherwise, I think it would be a good idea to reject the `camel_case` and `kebab_case` specifications.

https://github.com/Peternator7/strum/pull/250/files#diff-801759161311a5149bd0d6c227fea4237bb6d8a8bb9e84f4703d305e2f131ae1R129

The serde crate rename_all attribute appears to reject it.

https://github.com/serde-rs/serde/blob/ce0844b9ecc32377b5e4545d759d385a8c46bc6a/serde_derive/src/internals/case.rs#L38-L59
