### PR TITLE
fix deprecation warning in additional_attributes example

### DIFF
--- a/strum/src/additional_attributes.rs
+++ b/strum/src/additional_attributes.rs
@@ -20,11 +20,9 @@
 //!   - `Train-Case`
 //!
 //!   ```rust
-//!   use std::string::ToString;
-//!   use strum;
 //!   use strum_macros;
 //!   
-//!   #[derive(Debug, Eq, PartialEq, strum_macros::ToString)]
+//!   #[derive(Debug, Eq, PartialEq, strum_macros::Display)]
 //!   #[strum(serialize_all = "snake_case")]
 //!   enum Brightness {
 //!       DarkBlack,


### PR DESCRIPTION
The example code in [additional_attributes](https://docs.rs/strum/latest/strum/additional_attributes/index.html) brings up a deprecation warning related to issue #132 .

This change updates the example code to use `strum_macros::Display` instead of `strum_macros::ToString` (as well as removing some unneeded use statements).

Current example code with warning:
![example_deprecation_warning](https://user-images.githubusercontent.com/4380339/232637386-b3404937-d1ff-40b0-be3a-a7d87b94b509.png)

Fixed:
![fixed](https://user-images.githubusercontent.com/4380339/232637447-92506229-a6d7-4ed2-becf-891bf9775147.png)
