### PR TITLE
Handle rustoc comments in `#[derive(FromRepr)]`

### DIFF
--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -16,7 +16,15 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     for attr in attrs {
         let path = attr.path();
 
-        let mut ts = attr.meta.require_list()?.to_token_stream().into_iter();
+        let mut ts = if let Ok(ts) = attr
+            .meta
+            .require_list()
+            .map(|metas| metas.to_token_stream().into_iter())
+        {
+            ts
+        } else {
+            continue;
+        };
         // Discard the path
         let _ = ts.next();
         let tokens: TokenStream = ts.collect();

--- a/strum_tests/tests/from_repr.rs
+++ b/strum_tests/tests/from_repr.rs
@@ -1,6 +1,7 @@
 use strum::FromRepr;
 
 #[derive(Debug, FromRepr, PartialEq)]
+/// Day of the week
 #[repr(u8)]
 enum Week {
     Sunday,


### PR DESCRIPTION
I think this fixes #275, but please scrutinize.