### PR TITLE
Enable doc-test for "strum_discriminants(vis(pub))"

### DIFF
--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -713,7 +713,7 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 /// of the generated enum. By default, the generated enum inherits the
 /// visibility of the parent enum it was generated from.
 ///
-/// ```nocompile
+/// ```
 /// use strum_macros::EnumDiscriminants;
 ///
 /// // You can set the visibility of the generated enum using the `#[strum_discriminants(vis(..))]` attribute:


### PR DESCRIPTION
This PR enables a previously disabled doc-test, i locally tested it and it tests fine and currently on [docs.rs](https://docs.rs/strum/0.25.0/strum/derive.EnumDiscriminants.html) it shows that code completely without syntax highlighting, making the code harder to read than necessary