### PR TITLE
feat: added discriminator fn

### DIFF
--- a/strum_macros/src/macros/enum_discriminants.rs
+++ b/strum_macros/src/macros/enum_discriminants.rs
@@ -122,15 +122,27 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         .collect::<Vec<_>>();
 
     let from_fn_body = quote! { match val { #(#arms),* } };
+    let discriminant_fn_body = quote! { match self { #(#arms),* } };
 
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
     let impl_from = quote! {
         impl #impl_generics ::core::convert::From< #name #ty_generics > for #discriminants_name #where_clause {
             fn from(val: #name #ty_generics) -> #discriminants_name {
                 #from_fn_body
             }
         }
+
     };
+
+    let impl_discriminant = quote! {
+        impl #impl_generics #name #ty_generics #where_clause {
+            pub fn discriminant(&self) -> #discriminants_name {
+                #discriminant_fn_body
+            }
+        }
+    };
+
     let impl_from_ref = {
         let mut generics = ast.generics.clone();
 
@@ -160,5 +172,6 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
         #impl_from
         #impl_from_ref
+        #impl_discriminant
     })
 }

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -186,6 +186,11 @@ fn from_ref_test() {
     assert_eq!(EnumIntoDiscriminants::B, (EnumInto::B(1)).into());
 }
 
+#[test]
+fn discriminant_fn_test() {
+    assert_eq!(EnumIntoDiscriminants::A, EnumInto::A(true).discriminant());
+}
+
 #[derive(Debug)]
 struct Rara;
 
@@ -305,3 +310,4 @@ fn crate_module_path_test() {
 
     assert_eq!(expected, discriminants);
 }
+

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -172,23 +172,28 @@ fn arbitrary_attributes_pass_through() {
 enum EnumInto {
     A(bool),
     B(i32),
+    C { a: i32 },
 }
 
 #[test]
 fn from_test() {
     assert_eq!(EnumIntoDiscriminants::A, EnumInto::A(true).into());
     assert_eq!(EnumIntoDiscriminants::B, EnumInto::B(1).into());
+    assert_eq!(EnumIntoDiscriminants::C, EnumInto::C { a: 1 }.into());
 }
 
 #[test]
 fn from_ref_test() {
     assert_eq!(EnumIntoDiscriminants::A, (EnumInto::A(true)).into());
     assert_eq!(EnumIntoDiscriminants::B, (EnumInto::B(1)).into());
+    assert_eq!(EnumIntoDiscriminants::C, (EnumInto::C { a: 1 }).into());
 }
 
 #[test]
 fn discriminant_fn_test() {
     assert_eq!(EnumIntoDiscriminants::A, EnumInto::A(true).discriminant());
+    assert_eq!(EnumIntoDiscriminants::B, EnumInto::B(1).discriminant());
+    assert_eq!(EnumIntoDiscriminants::C, EnumInto::C { a: 1 }.discriminant());
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
I've just added a `discriminant()` function which from the original enum returns it matched discriminant. 
Is just less verbose. 