### PR TITLE
Implement TryFrom<String> in EnumString

### DIFF
--- a/strum_tests/tests/phf.rs
+++ b/strum_tests/tests/phf.rs
@@ -13,7 +13,25 @@ fn from_str_with_phf() {
     assert_eq!("Red".parse::<Color>().unwrap(), Color::Red);
     assert_eq!("bLuE".parse::<Color>().unwrap(), Color::Blue);
 }
-
+#[cfg(feature = "test_phf")]
+#[test]
+fn from_str_with_phf_default() {
+    #[derive(Debug, PartialEq, Eq, Clone, strum::EnumString)]
+    #[strum(use_phf)]
+    enum Color {
+        #[strum(ascii_case_insensitive)]
+        Blue,
+        Red,
+        #[strum(default)]
+        Default(String),
+    }
+    assert_eq!("Red".parse::<Color>().unwrap(), Color::Red);
+    assert_eq!("bLuE".parse::<Color>().unwrap(), Color::Blue);
+    assert_eq!(
+        "Green".parse::<Color>().unwrap(),
+        Color::Default("Green".into())
+    );
+}
 #[cfg(feature = "test_phf")]
 #[test]
 fn from_str_with_phf_big() {


### PR DESCRIPTION
Implement `TryFrom<String>` during EnumString

If no default variant is provided it will just call `FromStr` other wise it will generate something similar to this

```rust
#[allow(clippy::use_self)]
impl ::core::convert::TryFrom<String> for Color {
    type Error = ::strum::ParseError;
    fn try_from(s: String) -> ::core::result::Result<Color, <Self as ::core::convert::TryFrom<String>>::Error> {
        ::core::result::Result::Ok(match s.as_str() {
            "RedRed" => Color::Red,
            "b" => Color::Blue { hue: Default::default() },
            "blue" => Color::Blue { hue: Default::default() },
            "y" => Color::Yellow,
            "yellow" => Color::Yellow,
            _ => return ::core::result::Result::Ok(Color::Green(s.into())), 
        })
    }
}
```
