### PR TITLE
Impl Copy, Eq, and FusedIterator for EnumIter iterators

### DIFF
--- a/strum_macros/src/macros/enum_iter.rs
+++ b/strum_macros/src/macros/enum_iter.rs
@@ -71,9 +71,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[doc = #doc_comment]
-        #[allow(
-            missing_copy_implementations,
-        )]
+        #[derive(Clone, Copy, Eq, PartialEq)]
         #vis struct #iter_name #ty_generics {
             idx: usize,
             back_idx: usize,
@@ -159,14 +157,6 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
-        impl #impl_generics Clone for #iter_name #ty_generics #where_clause {
-            fn clone(&self) -> #iter_name #ty_generics {
-                #iter_name {
-                    idx: self.idx,
-                    back_idx: self.back_idx,
-                    marker: self.marker.clone(),
-                }
-            }
-        }
+        impl #impl_generics ::core::iter::FusedIterator for #iter_name #ty_generics #where_clause { }
     })
 }


### PR DESCRIPTION
* The fields within `EnumIter` types (`usize` and `PhantomData`) all implement `Clone`, `Copy`, `Eq`, and `PartialEq`, so we can derive all of those on the iterator types.

* Once an `EnumIter` reaches the end of its values, it only ever yields `None`.  This means we can implement `FusedIterator` on it.