### PR TITLE
Add `EnumDeref` trait and derive

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Strum has implemented the following macros:
 | [EnumDiscriminants] | Generate a new type with only the discriminant names. |
 | [EnumCount] | Add a constant `usize` equal to the number of variants. |
 | [StaticVariantsArray] | Adds an associated `ALL_VARIANTS` constant which is an array of all enum discriminants |
+| [EnumDeref] | Implements `Deref` and `DeretMut` for a new-type enum based on a common `Target` |
 
 # Contributing
 
@@ -83,3 +84,4 @@ Strumming is also a very whimsical motion, much like writing Rust code.
 [EnumCount]: https://docs.rs/strum_macros/0.25/strum_macros/derive.EnumCount.html
 [FromRepr]: https://docs.rs/strum_macros/0.25/strum_macros/derive.FromRepr.html
 [StaticVariantsArray]: https://docs.rs/strum_macros/0.25/strum_macros/derive.StaticVariantsArray.html
+[EnumDeref]: https://docs.rs/strum_macros/0.25/strum_macros/derive.EnumDeref.html

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -206,7 +206,9 @@ pub trait EnumCount {
     const COUNT: usize;
 }
 
-/// TODO: Doc this
+/// A trait for reducing boilerplate code related to common access patterns in
+/// new-type-like variant enums. Because of this, for derived usage, all the
+/// variants in the enumerator need to be new-types (e.g. Int(i32), Person(Person))
 pub trait EnumDeref: std::ops::Deref + std::ops::DerefMut {}
 
 impl<T: std::ops::Deref + std::ops::DerefMut> EnumDeref for T {}

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -206,6 +206,11 @@ pub trait EnumCount {
     const COUNT: usize;
 }
 
+/// TODO: Doc this
+pub trait EnumDeref: std::ops::Deref + std::ops::DerefMut {}
+
+impl<T: std::ops::Deref + std::ops::DerefMut> EnumDeref for T {}
+
 /// A trait for retrieving the names of each variant in Enum. This trait can
 /// be autoderived by `strum_macros`.
 pub trait VariantNames {

--- a/strum_macros/src/helpers/mod.rs
+++ b/strum_macros/src/helpers/mod.rs
@@ -25,6 +25,22 @@ pub fn non_unit_variant_error() -> syn::Error {
     )
 }
 
+pub fn non_new_type_variant_error(additional_info: &str) -> syn::Error {
+    syn::Error::new(
+        Span::call_site(),
+        format!(
+            "This macro only supports enums of strictly new type variants, but {additional_info}"
+        ),
+    )
+}
+
+pub fn no_associated_deref_type_specified() -> syn::Error {
+    syn::Error::new(
+        Span::call_site(),
+        "expected a deref target specified via attribute, e.g. #[strum_deref(T)]",
+    )
+}
+
 pub fn strum_discriminants_passthrough_error(span: &impl Spanned) -> syn::Error {
     syn::Error::new(
         span.span(),

--- a/strum_macros/src/helpers/mod.rs
+++ b/strum_macros/src/helpers/mod.rs
@@ -9,9 +9,10 @@ mod metadata;
 pub mod type_props;
 pub mod variant_props;
 
-use proc_macro2::Span;
+use proc_macro2::{Ident, Span};
 use quote::ToTokens;
 use syn::spanned::Spanned;
+use syn::{Fields, FieldsUnnamed, Type, Variant};
 
 pub fn non_enum_error() -> syn::Error {
     syn::Error::new(Span::call_site(), "This macro only supports enums.")
@@ -37,7 +38,7 @@ pub fn non_new_type_variant_error(additional_info: &str) -> syn::Error {
 pub fn no_associated_deref_type_specified() -> syn::Error {
     syn::Error::new(
         Span::call_site(),
-        "expected a deref target specified via attribute, e.g. #[strum_deref(T)]",
+        "expected a deref target specified via attribute, e.g. #[strum_deref_target(T)]",
     )
 }
 
@@ -55,4 +56,24 @@ pub fn occurrence_error<T: ToTokens>(fst: T, snd: T, attr: &str) -> syn::Error {
     );
     e.combine(syn::Error::new_spanned(fst, "first one here"));
     e
+}
+
+pub fn get_new_type_variant(enum_variant: &Variant) -> syn::Result<(Ident, Type)> {
+    match &enum_variant.fields {
+        Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
+            if unnamed.len() != 1 {
+                Err(non_new_type_variant_error(
+                    "the list of type parameters is different from 1",
+                ))
+            } else if let Some(new_type) = unnamed.first() {
+                Ok((enum_variant.ident.clone(), new_type.ty.clone()))
+            } else {
+                unreachable!("`unnamed.len()` must be 1 in the previous branch, so `.first()` should not return `None`");
+            }
+        }
+        _ => Err(non_new_type_variant_error(&format!(
+            "the variant {} is not a tuple-struct",
+            enum_variant.ident
+        ))),
+    }
 }

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -905,7 +905,6 @@ pub fn enum_count(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// 
 /// ```
 /// use strum::EnumDeref;
-/// use strum_macros::EnumDeref;
 /// 
 /// #[derive(EnumDeref)]
 /// #[strum_deref_target([u32])]
@@ -933,7 +932,6 @@ pub fn enum_count(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///
 /// ```
 /// use strum::EnumDeref;
-/// use strum_macros::EnumDeref;
 /// 
 /// #[derive(EnumDeref)]
 /// #[strum_deref_target(dyn core::fmt::Display)]

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -891,7 +891,75 @@ pub fn enum_count(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     toks.into()
 }
 
-/// TODO: Doc this
+/// A trait for grouping together different new-type variants that dereference to
+/// the same type, reducing boilerplate code.
+/// 
+/// Implements [`std::ops::Deref`] and [`std::ops::DerefMut`] for enums composed
+/// of  solely of new-type-style variants.
+/// 
+/// The variants must hold "compatible" types, which means they must be deref-able
+/// to the same type (e.g. String and &str, Box<T> and T).
+/// 
+/// The macro accompanies the macro-attribute `strum_deref_target` to define what type the enum should
+/// deref to.
+/// 
+/// ```
+/// use strum::EnumDeref;
+/// use strum_macros::EnumDeref;
+/// 
+/// #[derive(EnumDeref)]
+/// #[strum_deref_target([u32])]
+/// enum Collection {
+///     Fixed([u32; 2]),
+///     Dynamic(Vec<u32>),
+/// }
+/// 
+/// let mut f = Collection::Fixed([5, 6]);
+/// assert_eq!(&*f, &[5, 6]);
+/// 
+/// f[0] = 10;
+/// assert_eq!(&*f, &[10, 6]);
+/// 
+/// let mut d = Collection::Dynamic(Vec::from([9]));
+/// assert_eq!(&*d, &[9]);
+/// 
+/// d[0] = 1;
+/// assert_eq!(&*d, &[1]);
+/// ```
+/// 
+/// You may also deref trait object references using `dyn Trait` for something
+/// resembling a `Box<T>`, but with all the benefits of having an enum
+/// (compile-time known variants, possibility of using other strum macros).
+///
+/// ```
+/// use strum::EnumDeref;
+/// use strum_macros::EnumDeref;
+/// 
+/// #[derive(EnumDeref)]
+/// #[strum_deref_target(dyn core::fmt::Display)]
+/// enum Column {
+///     Text(String),
+///     Number(i32),
+///     Float(f32),
+/// }
+/// 
+/// let t = Column::Text("Hi!".to_string());
+/// assert_eq!((*t).to_string(), "Hi!");
+/// 
+/// let n = Column::Number(4);
+/// assert_eq!((*n).to_string(), "4");
+/// 
+/// let f = Column::Float(5.125);
+/// assert_eq!((*f).to_string(), "5.125");
+/// 
+/// fn prints_something(smth: &dyn core::fmt::Display) {
+///     println!("{smth}");
+/// }
+/// 
+/// prints_something(&*t);
+/// prints_something(&*n);
+/// prints_something(&*f);
+/// ```
 #[proc_macro_derive(EnumDeref, attributes(strum, strum_deref_target))]
 pub fn enum_deref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse_macro_input!(input as DeriveInput);

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -890,3 +890,14 @@ pub fn enum_count(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     debug_print_generated(&ast, &toks);
     toks.into()
 }
+
+/// TODO: Doc this
+#[proc_macro_derive(EnumDeref, attributes(strum, strum_deref_target))]
+pub fn enum_deref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = syn::parse_macro_input!(input as DeriveInput);
+
+    let toks = macros::enum_deref::enum_deref_inner(&ast)
+        .unwrap_or_else(|err| err.to_compile_error());
+    debug_print_generated(&ast, &toks);
+    toks.into()
+}

--- a/strum_macros/src/macros/enum_deref.rs
+++ b/strum_macros/src/macros/enum_deref.rs
@@ -1,0 +1,71 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, FieldsUnnamed, Meta};
+
+use crate::helpers::{
+    no_associated_deref_type_specified, non_enum_error, non_new_type_variant_error,
+};
+
+pub fn enum_deref_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
+    let name = &ast.ident;
+    let gen = &ast.generics;
+    let attrs = &ast.attrs;
+    let (impl_generics, ty_generics, where_clause) = gen.split_for_impl();
+
+    let variants = match &ast.data {
+        Data::Enum(v) => &v.variants,
+        _ => return Err(non_enum_error()),
+    };
+
+    let target_type = attrs
+        .iter()
+        .find_map(|attr| {
+            if attr.path().is_ident("strum_deref_target") {
+                if let Meta::List(list) = &attr.meta {
+                    return Some(&list.tokens);
+                }
+            }
+            None
+        })
+        .ok_or_else(no_associated_deref_type_specified)?;
+
+    let idents: Vec<Ident> = variants
+        .iter()
+        .cloned()
+        .map(|v| match &v.fields {
+            Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
+                if unnamed.len() != 1 {
+                    Err(non_new_type_variant_error(
+                        "the list of type parameters is different from 1",
+                    ))
+                } else {
+                    Ok(v.ident.clone())
+                }
+            }
+            _ => Err(non_new_type_variant_error(&format!(
+                "the variant {} is not a tuple-struct",
+                v.ident
+            ))),
+        })
+        .collect::<syn::Result<_>>()?;
+
+    Ok(quote! {
+        impl #impl_generics std::ops::Deref for #name #ty_generics #where_clause {
+            type Target = #target_type;
+
+            fn deref(&self) -> &Self::Target {
+                match self {
+                    #( #name::#idents (ref inner) => inner, )*
+                }
+            }
+        }
+
+        impl #impl_generics std::ops::DerefMut for #name #ty_generics #where_clause {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                match self {
+                    #( #name::#idents (ref mut inner) => inner, )*
+                }
+            }
+        }
+    })
+}

--- a/strum_macros/src/macros/mod.rs
+++ b/strum_macros/src/macros/mod.rs
@@ -1,4 +1,5 @@
 pub mod enum_count;
+pub mod enum_deref;
 pub mod enum_discriminants;
 pub mod enum_is;
 pub mod enum_iter;

--- a/strum_tests/tests/enum_deref.rs
+++ b/strum_tests/tests/enum_deref.rs
@@ -123,3 +123,34 @@ fn traits() {
     assert_eq!(person.distance_walked(), 1500_f32);
     assert_eq!(ant.distance_walked(), 0.125_f32);
 }
+
+#[test]
+fn stack_and_heap() {
+    #[derive(EnumDeref)]
+    #[strum_deref_target(i32)]
+    enum Storage {
+        Stack(i32),
+        Heap(Box<i32>),
+    }
+
+    let mut stack = Storage::Stack(5);
+    let mut heap = Storage::Heap(Box::new(3));
+
+    {
+        // Assert that the compiler accepts the derefs
+        let _: &i32 = &stack;
+        let _: &i32 = &heap;
+
+        let _: &mut i32 = &mut stack;
+        let _: &mut i32 = &mut heap;
+    }
+
+    assert_eq!(*stack, 5);
+    assert_eq!(*heap, 3);
+
+    *stack += 10;
+    *heap *= 2;
+
+    assert_eq!(*stack, 15);
+    assert_eq!(*heap, 6);
+}

--- a/strum_tests/tests/enum_deref.rs
+++ b/strum_tests/tests/enum_deref.rs
@@ -1,0 +1,125 @@
+use std::ops::{Deref, DerefMut};
+use strum::EnumDeref;
+
+mod core {} // ensure macros call `::core`
+
+#[test]
+fn homogeneous_enum() {
+    #[derive(EnumDeref)]
+    #[strum_deref_target(str)]
+    enum Name {
+        FirstName(String),
+        NameAndSurname(String),
+    }
+
+    let first_name = Name::FirstName("Mario".to_owned());
+    let name_n_surname = Name::NameAndSurname("Gordon Freeman".to_owned());
+
+    {
+        // Assert that the compiler accepts the derefs
+        let _: &str = &first_name;
+        let _: &str = &name_n_surname;
+    }
+
+    assert_eq!(first_name.deref(), "Mario");
+    assert_eq!(name_n_surname.deref(), "Gordon Freeman");
+}
+
+#[test]
+fn heterogeneous_enum() {
+    #[derive(Debug, EnumDeref)]
+    #[strum_deref_target([u32])]
+    enum Collection {
+        Fixed([u32; 8]),
+        Dynamic(Vec<u32>),
+    }
+
+    let mut fixed = Collection::Fixed([0, 1, 2, 3, 4, 5, 6, 7]);
+    let mut dynamic = Collection::Dynamic(Vec::from([10, 21, 32]));
+
+    assert_eq!(&*fixed, &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(&*dynamic, &[10, 21, 32]);
+
+    {
+        // Assert that the compiler accepts the derefs
+        let _: &[u32] = &fixed;
+        let _: &[u32] = &dynamic;
+
+        let _: &mut [u32] = &mut fixed;
+        let _: &mut [u32] = &mut dynamic;
+    }
+
+    fixed[4] = 400;
+    dynamic[0] = 140;
+
+    assert!(matches!(fixed, Collection::Fixed(a) if a[4] == 400));
+    assert!(matches!(dynamic, Collection::Dynamic(v) if v.first().is_some_and(|i| *i == 140)));
+}
+
+#[test]
+fn traits() {
+    trait Walker {
+        fn distance_walked(&self) -> f32;
+        fn walk(&mut self);
+    }
+
+    struct Person {
+        distance_walked: u32,
+    }
+
+    impl Walker for Person {
+        fn distance_walked(&self) -> f32 {
+            self.distance_walked as f32
+        }
+
+        fn walk(&mut self) {
+            self.distance_walked += 500;
+        }
+    }
+
+    struct Ant {
+        feets_moved: u32,
+    }
+
+    impl Walker for Ant {
+        fn distance_walked(&self) -> f32 {
+            self.feets_moved as f32 * 0.125
+        }
+
+        fn walk(&mut self) {
+            self.feets_moved += 1
+        }
+    }
+
+    #[derive(EnumDeref)]
+    #[strum_deref_target(dyn Walker)]
+    enum AntiBox {
+        Person(Person),
+        Ant(Ant),
+    }
+
+    let mut person = AntiBox::Person(Person {
+        distance_walked: 1000,
+    });
+    let mut ant = AntiBox::Ant(Ant { feets_moved: 0 });
+
+    {
+        // Assert that the compiler accepts the derefs
+        // Because we're dealing with `dyn Trait`s, implicit deref-ing won't work
+        // in variable assignments
+        let _: &dyn Walker = person.deref();
+        let _: &dyn Walker = ant.deref();
+
+        let _: &mut dyn Walker = person.deref_mut();
+        let _: &mut dyn Walker = ant.deref_mut();
+    }
+
+    assert_eq!(person.distance_walked(), 1000_f32);
+    assert_eq!(ant.distance_walked(), 0_f32);
+
+    person.walk();
+    ant.walk();
+
+    assert_eq!(person.distance_walked(), 1500_f32);
+    assert_eq!(ant.distance_walked(), 0.125_f32);
+}

--- a/strum_tests/tests/enum_deref.rs
+++ b/strum_tests/tests/enum_deref.rs
@@ -125,7 +125,7 @@ fn traits() {
 }
 
 #[test]
-fn stack_and_heap() {
+fn multi_level_deref() {
     #[derive(EnumDeref)]
     #[strum_deref_target(i32)]
     enum Storage {


### PR DESCRIPTION
## About this PR

This PR introduces a new trait and derive `EnumDeref` for automatically implementing `Deref` and `DerefMut` in enumerators composed of new-type-style variants.

## Motivation

The primary motivation for this feature is included as one of the tests and doc-tests: "tagged boxes". With this trait, it's possible to avoid the usage of `Box<dyn Trait>` for grouping structs based on behavior. The advantages of using an enum instead of the former are clear as day:
- No pointer access;
- All variants are known at compile time;
- Possibility of using other `strum` macros.