### PR TITLE
Add `attributes` to `strum_discriminants` for custom attributes in generated discriminant enum

### DIFF
--- a/strum_macros/src/helpers/metadata.rs
+++ b/strum_macros/src/helpers/metadata.rs
@@ -3,8 +3,8 @@ use syn::{
     parse::{Parse, ParseStream},
     parse2, parse_str,
     punctuated::Punctuated,
-    Attribute, DeriveInput, Expr, ExprLit, Field, Ident, Lit, LitBool, LitStr, Meta, MetaNameValue,
-    Path, Token, Variant, Visibility,
+    Attribute, DeriveInput, Expr, ExprLit, Field, Ident, Lit, LitBool, LitStr, Meta, MetaList,
+    MetaNameValue, Path, Token, Variant, Visibility,
 };
 
 use super::case_style::CaseStyle;
@@ -27,6 +27,7 @@ pub mod kw {
     custom_keyword!(name);
     custom_keyword!(vis);
     custom_keyword!(doc);
+    custom_keyword!(attributes);
 
     // variant metadata
     custom_keyword!(message);
@@ -125,6 +126,7 @@ pub enum EnumDiscriminantsMeta {
     Derive { _kw: kw::derive, paths: Vec<Path> },
     Name { kw: kw::name, name: Ident },
     Vis { kw: kw::vis, vis: Visibility },
+    Attributes { _kw: kw::attributes, attributes: Vec<MetaList> },
     Other { passthrough_meta: Meta },
 }
 
@@ -151,6 +153,15 @@ impl Parse for EnumDiscriminantsMeta {
             parenthesized!(content in input);
             let vis = content.parse()?;
             Ok(EnumDiscriminantsMeta::Vis { kw, vis })
+        } else if input.peek(kw::attributes) {
+            let _kw = input.parse()?;
+            let content;
+            parenthesized!(content in input);
+            let attributes = content.parse_terminated(MetaList::parse, Token![,])?;
+            Ok(EnumDiscriminantsMeta::Attributes {
+                _kw,
+                attributes: attributes.into_iter().collect(),
+            })
         } else {
             let passthrough_meta = input.parse()?;
             Ok(EnumDiscriminantsMeta::Other { passthrough_meta })

--- a/strum_macros/src/helpers/type_props.rs
+++ b/strum_macros/src/helpers/type_props.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use std::default::Default;
-use syn::{parse_quote, DeriveInput, Ident, LitStr, Meta, Path, Visibility};
+use syn::{parse_quote, DeriveInput, Ident, LitStr, Meta, MetaList, Path, Visibility};
 
 use super::case_style::CaseStyle;
 use super::metadata::{DeriveInputExt, EnumDiscriminantsMeta, EnumMeta};
@@ -21,6 +21,7 @@ pub struct StrumTypeProperties {
     pub discriminant_name: Option<Ident>,
     pub discriminant_others: Vec<Meta>,
     pub discriminant_vis: Option<Visibility>,
+    pub discriminant_attributes: Vec<MetaList>,
     pub use_phf: bool,
     pub prefix: Option<LitStr>,
     pub suffix: Option<LitStr>,
@@ -147,6 +148,9 @@ impl HasTypeProperties for DeriveInput {
 
                     vis_kw = Some(kw);
                     output.discriminant_vis = Some(vis);
+                }
+                EnumDiscriminantsMeta::Attributes { attributes, .. } => {
+                    output.discriminant_attributes.extend(attributes);
                 }
                 EnumDiscriminantsMeta::Other { passthrough_meta } => {
                     output.discriminant_others.push(passthrough_meta);

--- a/strum_macros/src/macros/enum_discriminants.rs
+++ b/strum_macros/src/macros/enum_discriminants.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::{quote, ToTokens};
-use syn::parse_quote;
+use syn::{parse_quote, MetaList};
 use syn::{Data, DeriveInput, Fields};
 
 use crate::helpers::{non_enum_error, strum_discriminants_passthrough_error, HasTypeProperties};
@@ -20,8 +20,23 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         _ => return Err(non_enum_error()),
     };
 
-    // Derives for the generated enum
     let type_properties = ast.get_type_properties()?;
+
+    // Attributes for the generated enum
+    let attributes: &Vec<MetaList> = &type_properties.discriminant_attributes;
+
+    let attributes: Vec<_> = attributes
+        .iter()
+        .map(|a| {
+            quote! {
+                #[#a]
+            }
+        })
+        .collect();
+
+    let attributes = quote! {#(#attributes)*};
+
+    // Derives for the generated enum
     let strum_module_path = type_properties.crate_module_path();
 
     let mut derives = type_properties.discriminant_derives;
@@ -223,6 +238,7 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     };
 
     Ok(quote! {
+        #attributes
         #derives
         #repr
         #(#[ #pass_through_attributes ])*


### PR DESCRIPTION
Sometimes derive macros need a specific attribute to be above them to work properly. I ran across this while using [bilge](https://crates.io/crates/bilge), where the [TryFromBits](https://docs.rs/bilge/0.2.0/bilge/derive.TryFromBits.html) derive macro requires the [bitsize](https://docs.rs/bilge/0.2.0/bilge/attr.bitsize.html) attribute above it. The `EnumDiscriminants` derive macro currently doesn't allow for arbitrary attribute macros before the generated enum's derives, so I added the `#[strum_discriminants(attributes(..))]` attribute to allow for this.

This PR is a draft because I am not entirely sure how a test for this specific attribute would be performed, and I wouldn't want it to get merged without its proper tests.