### PR TITLE
Fixed the `fmt` conflict caused by using `use std::fmt::Debug`

### DIFF
--- a/strum_macros/src/macros/strings/display.rs
+++ b/strum_macros/src/macros/strings/display.rs
@@ -38,7 +38,7 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         if variant_properties.to_string.is_none() && variant_properties.default.is_some() {
             match &variant.fields {
                 Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
-                    arms.push(quote! { #name::#ident(ref s) => s.fmt(f) });
+                    arms.push(quote! { #name::#ident(ref s) => ::core::fmt::Display::fmt(s, f) });
                 }
                 _ => {
                     return Err(syn::Error::new_spanned(
@@ -48,7 +48,7 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                 }
             }
         } else {
-            arms.push(quote! { #name::#ident #params => (#output).fmt(f) } );
+            arms.push(quote! { #name::#ident #params => ::core::fmt::Display::fmt(#output, f) } );
         }
     }
 


### PR DESCRIPTION
```rust

use std::fmt::Debug; // <--- add this line, for example some people might wish to custom implement the Debug trait

#[derive(Eq, PartialEq, EnumString, Display, EnumCount, EnumDiscriminants, EnumIs)]
pub enum Color {
    /// Docs on red
    #[strum(to_string = "RedRed")]
    Red,
    #[strum(serialize = "b", to_string = "blue")]
    Blue { hue: usize },
    #[strum(serialize = "y", serialize = "yellow")]
    Yellow,
    #[strum(disabled)]
    Green(String),
}

impl Debug for Color {
    ...
}

```
This will cause the following error.
```shell
error[E0034]: multiple applicable items in scope
 --> strum_tests/src/lib.rs:5:44
  |
5 | #[derive(Debug, Eq, PartialEq, EnumString, Display, EnumCount, EnumDiscriminants, EnumIs)]
  |                                            ^^^^^^^ multiple `fmt` found
  |
  = note: candidate #1 is defined in an impl of the trait `Debug` for the type `str`
  = note: candidate #2 is defined in an impl of the trait `std::fmt::Display` for the type `str`
  = note: this error originates in the derive macro `Display` (in Nightly builds, run with -Z macro-backtrace for more info)
```