### PR TITLE
fix: use core not std to allow no_std to compile

### DIFF
--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -223,7 +223,7 @@ pub trait VariantNames {
 /// enums with inner data in one or more variants. Consider using it alongside
 /// [`EnumDiscriminants`] if you require inner data but still want to have an
 /// static array of variants.
-pub trait VariantArray: std::marker::Sized + 'static {
+pub trait VariantArray: core::marker::Sized + 'static {
     const VARIANTS: &'static [Self];
 }
 


### PR DESCRIPTION
Getting a compile error on `no_std` for the new `v0.26.0` release:
```
> cargo check
error[E0433]: failed to resolve: use of undeclared crate or module `std`
   --> strum/src/lib.rs:226:25
    |
226 | pub trait VariantArray: std::marker::Sized + 'static {
    |                         ^^^ use of undeclared crate or module `std`
    |
help: consider importing this module
    |
33  + use core::marker;
    |
help: if you import `marker`, refer to it directly
    |
226 - pub trait VariantArray: std::marker::Sized + 'static {
226 + pub trait VariantArray: marker::Sized + 'static {
    |

For more information about this error, try `rustc --explain E0433`.
error: could not compile `strum` (lib) due to 1 previous error
```

The fix was to use `core` not `std`.
I'm surprised this sort of thing isn't caught by CI tests?