### PR TITLE
Fix missing generics on impl for EnumTryAs

### DIFF
--- a/strum_macros/src/macros/enum_try_as.rs
+++ b/strum_macros/src/macros/enum_try_as.rs
@@ -10,6 +10,7 @@ pub fn enum_try_as_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     };
 
     let enum_name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
     let variants: Vec<_> = variants
         .iter()
@@ -72,9 +73,8 @@ pub fn enum_try_as_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         .collect();
 
     Ok(quote! {
-        impl #enum_name {
+        impl #impl_generics #enum_name #ty_generics #where_clause {
             #(#variants)*
         }
-    }
-    .into())
+    })
 }


### PR DESCRIPTION
The EnumTryAs impl currently does not pass through generic parameters from the enum.
```rust
#[derive(Debug, EnumTryAs)]
    pub enum ConstantInfo<'a> {
        Utf8(bumpalo::collections::String<'a>),
    }
```
generates
```rust
impl ConstantInfo {
    #[must_use]
    #[inline]
    pub fn try_as_utf_8(self) -> ::core::option::Option<(bumpalo::collections::String<'a>)> {
        match self {
            ConstantInfo::Utf8(x) => Some((x)),
            _ => None,
        }
    }
    ...
}
```
which doesn't compile.