### PR TITLE
Update `heck` requirement

### DIFF
--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 name = "strum_macros"
 
 [dependencies]
-heck = "0.4.1"
+heck = "0.5.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 rustversion = "1.0"


### PR DESCRIPTION
A new version of `heck` was recently released: https://github.com/withoutboats/heck/commit/070693322aee7c5c7fbee7c9964bf8d7d3a29c96