### PR TITLE
add hyperlinks to documentation and clarify derive macros

### DIFF
--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -67,7 +67,7 @@ impl std::error::Error for ParseError {
 }
 
 /// This trait designates that an `Enum` can be iterated over. It can
-/// be auto generated using `strum_macros` on your behalf.
+/// be auto generated using the [`EnumIter`](derive.EnumIter.html) derive macro.
 ///
 /// # Example
 ///

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -3,6 +3,10 @@
 //! Strum is a set of macros and traits for working with
 //! enums and strings easier in Rust.
 //!
+//! This crate only contains derive macros for use with the
+//! [`strum`](https://docs.rs/strum)
+//! crate.  The macros provied by this crate are also available by
+//! enabling the `derive` feature in aforementioned `strum` crate.
 
 #![recursion_limit = "128"]
 
@@ -428,7 +432,7 @@ pub fn display(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// Creates a new type that iterates of the variants of an enum.
 ///
 /// Iterate over the variants of an Enum. Any additional data on your variants will be set to `Default::default()`.
-/// The macro implements `strum::IntoEnumIterator` on your enum and creates a new type called `YourEnumIter` that is the iterator object.
+/// The macro implements [`strum::IntoEnumIterator`](https://docs.rs/strum/latest/strum/trait.IntoEnumIterator.html) on your enum and creates a new type called `YourEnumIter` that is the iterator object.
 /// You cannot derive `EnumIter` on any type with a lifetime bound (`<'a>`) because the iterator would surely
 /// create [unbounded lifetimes](https://doc.rust-lang.org/nightly/nomicon/unbounded-lifetimes.html).
 ///


### PR DESCRIPTION
this makes it easier to navigate the documentation.

one comment seemed to suggest that the reexport of the derive macros was depricated, however that has been ignored for several reasons:

1. exposing macros through a derive feature flag is common practice, see the serde crate for an example.
2. using a feature flag means you can't accidentally have a version mismatch.
3. the reexport is used in several examples
4. the only evidence of deprication is a private comment, which would never be seen by normal users of the crate.