### PR TITLE
Use fully qualified syntax for calling `get` on an `EnumIter`, eliminating ambiguities

### DIFF
--- a/strum_macros/src/macros/enum_iter.rs
+++ b/strum_macros/src/macros/enum_iter.rs
@@ -131,7 +131,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                     ::core::option::Option::None
                 } else {
                     self.idx = idx;
-                    self.get(idx - 1)
+                    #iter_name::get(self, idx - 1)
                 }
             }
         }
@@ -154,7 +154,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                     ::core::option::Option::None
                 } else {
                     self.back_idx = back_idx;
-                    self.get(#variant_count - self.back_idx)
+                    #iter_name::get(self, #variant_count - self.back_idx)
                 }
             }
         }


### PR DESCRIPTION
[`itertools`](https://docs.rs/itertools) version 0.13.0 added a `get` method that takes precedence over the `EnumIter`'s `get` method. So you can no longer import `itertools::Itertools` in a module where you want to derive `EnumIter`.

To fix this we call `get` via fully qualified syntax.

Fixes #358.