### PR TITLE
fix: require strum_macros 0.26.3

### DIFF
--- a/strum/Cargo.toml
+++ b/strum/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/Peternator7/strum"
 readme = "../README.md"
 
 [dependencies]
-strum_macros = { path = "../strum_macros", optional = true, version = "0.26" }
+strum_macros = { path = "../strum_macros", optional = true, version = "0.26.3" }
 phf = { version = "0.10", features = ["macros"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This is required for compatibility with itertools 0.13.0 fixed in #358

Fixes: https://github.com/Peternator7/strum/issues/364
