### PR TITLE
Useful changes to `EnumString`

### DIFF
--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -23,7 +23,7 @@ heck = "0.5.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 rustversion = "1.0"
-syn = { version = "2.0", features = ["parsing", "extra-traits"] }
+syn = { version = "2.0", features = ["parsing", "extra-traits", "visit"] }
 
 [dev-dependencies]
 strum = { path = "../strum", version= "0.26" }

--- a/strum_macros/src/helpers/case_style.rs
+++ b/strum_macros/src/helpers/case_style.rs
@@ -116,6 +116,23 @@ impl CaseStyleHelpers for Ident {
     }
 }
 
+/// heck doesn't treat numbers as new words, but this function does.
+/// E.g. for input `Hello2You`, heck would output `hello2_you`, and snakify would output `hello_2_you`.
+pub fn snakify(s: &str) -> String {
+    let mut output: Vec<char> = s.to_string().to_snake_case().chars().collect();
+    let mut num_starts = vec![];
+    for (pos, c) in output.iter().enumerate() {
+        if c.is_ascii_digit() && pos != 0 && !output[pos - 1].is_ascii_digit() {
+            num_starts.push(pos);
+        }
+    }
+    // need to do in reverse, because after inserting, all chars after the point of insertion are off
+    for i in num_starts.into_iter().rev() {
+        output.insert(i, '_')
+    }
+    output.into_iter().collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,21 +175,4 @@ mod tests {
 
         assert_eq!(MixedCase, f("mixed_case").unwrap());
     }
-}
-
-/// heck doesn't treat numbers as new words, but this function does.
-/// E.g. for input `Hello2You`, heck would output `hello2_you`, and snakify would output `hello_2_you`.
-pub fn snakify(s: &str) -> String {
-    let mut output: Vec<char> = s.to_string().to_snake_case().chars().collect();
-    let mut num_starts = vec![];
-    for (pos, c) in output.iter().enumerate() {
-        if c.is_digit(10) && pos != 0 && !output[pos - 1].is_digit(10) {
-            num_starts.push(pos);
-        }
-    }
-    // need to do in reverse, because after inserting, all chars after the point of insertion are off
-    for i in num_starts.into_iter().rev() {
-        output.insert(i, '_')
-    }
-    output.into_iter().collect()
 }

--- a/strum_macros/src/helpers/lifetime_check.rs
+++ b/strum_macros/src/helpers/lifetime_check.rs
@@ -1,0 +1,20 @@
+use syn::visit::Visit;
+
+#[derive(Default)]
+struct LifetimeVisitor {
+    contains_lifetime: bool,
+}
+
+impl<'ast> Visit<'ast> for LifetimeVisitor {
+    fn visit_lifetime(&mut self, i: &'ast syn::Lifetime) {
+        self.contains_lifetime = true;
+        syn::visit::visit_lifetime(self, i);
+    }
+}
+
+pub fn contains_lifetime(ty: &syn::Type) -> bool {
+    let mut visitor = LifetimeVisitor::default();
+    visitor.visit_type(ty);
+
+    visitor.contains_lifetime
+}

--- a/strum_macros/src/helpers/mod.rs
+++ b/strum_macros/src/helpers/mod.rs
@@ -5,6 +5,7 @@ pub use self::variant_props::HasStrumVariantProperties;
 
 pub mod case_style;
 pub mod inner_variant_props;
+pub mod lifetime_check;
 mod metadata;
 pub mod type_props;
 pub mod variant_props;

--- a/strum_macros/src/macros/enum_is.rs
+++ b/strum_macros/src/macros/enum_is.rs
@@ -42,6 +42,5 @@ pub fn enum_is_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         impl #impl_generics #enum_name  #ty_generics #where_clause {
             #(#variants)*
         }
-    }
-    .into())
+    })
 }

--- a/strum_macros/src/macros/enum_try_as.rs
+++ b/strum_macros/src/macros/enum_try_as.rs
@@ -64,9 +64,7 @@ pub fn enum_try_as_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                         }
                     })
                 },
-                _ => {
-                    return None;
-                }
+                _ => None
             }
 
         })

--- a/strum_macros/src/macros/strings/display.rs
+++ b/strum_macros/src/macros/strings/display.rs
@@ -37,7 +37,8 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                     .enumerate()
                     .map(|(index, field)| {
                         assert!(field.ident.is_none());
-                        let ident = syn::parse_str::<Ident>(format!("field{}", index).as_str()).unwrap();
+                        let ident =
+                            syn::parse_str::<Ident>(format!("field{}", index).as_str()).unwrap();
                         quote! { ref #ident }
                     })
                     .collect();
@@ -97,14 +98,14 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                             #name::#ident #params => ::core::fmt::Display::fmt(&format!(#output, #args), f)
                         }
                     }
-                },
+                }
                 Fields::Unnamed(ref unnamed_fields) => {
                     let used_vars = capture_format_strings(&output)?;
                     if used_vars.iter().any(String::is_empty) {
                         return Err(syn::Error::new_spanned(
                             &output,
                             "Empty {} is not allowed; Use manual numbering ({0})",
-                        ))
+                        ));
                     }
                     if used_vars.is_empty() {
                         quote! { #name::#ident #params => ::core::fmt::Display::fmt(#output, f) }
@@ -157,14 +158,17 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 }
 
 fn capture_format_string_idents(string_literal: &LitStr) -> syn::Result<Vec<Ident>> {
-    capture_format_strings(string_literal)?.into_iter().map(|ident| {
-        syn::parse_str::<Ident>(ident.as_str()).map_err(|_| {
-            syn::Error::new_spanned(
-                string_literal,
-                "Invalid identifier inside format string bracket",
-            )
+    capture_format_strings(string_literal)?
+        .into_iter()
+        .map(|ident| {
+            syn::parse_str::<Ident>(ident.as_str()).map_err(|_| {
+                syn::Error::new_spanned(
+                    string_literal,
+                    "Invalid identifier inside format string bracket",
+                )
+            })
         })
-    }).collect()
+        .collect()
 }
 
 fn capture_format_strings(string_literal: &LitStr) -> syn::Result<Vec<String>> {
@@ -193,7 +197,7 @@ fn capture_format_strings(string_literal: &LitStr) -> syn::Result<Vec<String>> {
             ))?;
 
             let inside_brackets = &format_str[start_index + 1..i];
-            let ident_str = inside_brackets.split(":").next().unwrap().trim_end();
+            let ident_str = inside_brackets.split(':').next().unwrap().trim_end();
             var_used.push(ident_str.to_owned());
         }
     }

--- a/strum_tests/src/lib.rs
+++ b/strum_tests/src/lib.rs
@@ -10,6 +10,6 @@ pub enum Color {
     Blue { hue: usize },
     #[strum(serialize = "y", serialize = "yellow")]
     Yellow,
-    #[strum(disabled)]
+    #[strum(default)]
     Green(String),
 }

--- a/strum_tests/tests/as_ref_str.rs
+++ b/strum_tests/tests/as_ref_str.rs
@@ -1,4 +1,4 @@
-#![allow(deprecated)]
+#![allow(deprecated, dead_code)]
 
 use std::str::FromStr;
 use strum::{AsRefStr, AsStaticRef, AsStaticStr, EnumString, IntoStaticStr};

--- a/strum_tests/tests/enum_is.rs
+++ b/strum_tests/tests/enum_is.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::borrow::Cow;
 use strum::EnumIs;
 
@@ -28,12 +30,9 @@ enum Foo {
 }
 #[test]
 fn generics_test() {
-    let foo = LifeTimeTest::One(Cow::Borrowed("Hello"));
-    assert!(foo.is_one());
-    let foo = LifeTimeTest::Two("Hello");
-    assert!(foo.is_two());
-    let foo = LifeTimeTest::One(Cow::Owned("Hello".to_string()));
-    assert!(foo.is_one());
+    assert!(LifeTimeTest::One(Cow::Borrowed("Hello")).is_one());
+    assert!(LifeTimeTest::Two("Hello").is_two());
+    assert!(LifeTimeTest::One(Cow::Owned("Hello".to_string())).is_one());
 }
 #[test]
 fn simple_test() {
@@ -47,19 +46,19 @@ fn named_0() {
 
 #[test]
 fn named_1() {
-    let foo = Foo::Named1 {
-        _a: Default::default(),
-    };
-    assert!(foo.is_named_1());
+    assert!(Foo::Named1 {
+        _a: Default::default()
+    }
+    .is_named_1());
 }
 
 #[test]
 fn named_2() {
-    let foo = Foo::Named2 {
+    assert!(Foo::Named2 {
         _a: Default::default(),
-        _b: Default::default(),
-    };
-    assert!(foo.is_named_2());
+        _b: Default::default()
+    }
+    .is_named_2());
 }
 
 #[test]
@@ -69,14 +68,12 @@ fn unnamed_0() {
 
 #[test]
 fn unnamed_1() {
-    let foo = Foo::Unnamed1(Default::default());
-    assert!(foo.is_unnamed_1());
+    assert!(Foo::Unnamed1(Default::default()).is_unnamed_1());
 }
 
 #[test]
 fn unnamed_2() {
-    let foo = Foo::Unnamed2(Default::default(), Default::default());
-    assert!(foo.is_unnamed_2());
+    assert!(Foo::Unnamed2(Default::default(), Default::default()).is_unnamed_2());
 }
 
 #[test]

--- a/strum_tests/tests/enum_try_as.rs
+++ b/strum_tests/tests/enum_try_as.rs
@@ -19,23 +19,24 @@ enum Foo {
 
 #[test]
 fn unnamed_0() {
-    let foo = Foo::Unnamed0();
-    assert_eq!(Some(()), foo.try_as_unnamed_0());
+    assert_eq!(Some(()), Foo::Unnamed0().try_as_unnamed_0());
 }
 
 #[test]
 fn unnamed_1() {
-    let foo = Foo::Unnamed1(128);
-    assert_eq!(Some(&128), foo.try_as_unnamed_1_ref());
+    assert_eq!(Some(&128), Foo::Unnamed1(128).try_as_unnamed_1_ref());
 }
 
 #[test]
 fn unnamed_2() {
-    let foo = Foo::Unnamed2(true, String::from("Hay"));
-    assert_eq!(Some((true, String::from("Hay"))), foo.try_as_unnamed_2());
+    assert_eq!(
+        Some((true, String::from("Hay"))),
+        Foo::Unnamed2(true, String::from("Hay")).try_as_unnamed_2()
+    );
 }
 
 #[test]
+#[allow(clippy::disallowed_names)]
 fn can_mutate() {
     let mut foo = Foo::Unnamed1(128);
     if let Some(value) = foo.try_as_unnamed_1_mut() {
@@ -46,6 +47,5 @@ fn can_mutate() {
 
 #[test]
 fn doesnt_match_other_variations() {
-    let foo = Foo::Unnamed1(66);
-    assert_eq!(None, foo.try_as_unnamed_0());
+    assert_eq!(None, Foo::Unnamed1(66).try_as_unnamed_0());
 }

--- a/strum_tests/tests/enum_variant_table.rs
+++ b/strum_tests/tests/enum_variant_table.rs
@@ -6,7 +6,7 @@ enum Color {
     Yellow,
     Green,
     #[strum(disabled)]
-    Teal,
+    _Teal,
     Blue,
     #[strum(disabled)]
     Indigo,
@@ -16,7 +16,7 @@ enum Color {
 // because if it doesn't compile, enum variants that conflict with keywords won't work
 #[derive(EnumTable)]
 enum Keyword {
-    Const,
+    _Const,
 }
 
 #[test]

--- a/strum_tests/tests/from_str.rs
+++ b/strum_tests/tests/from_str.rs
@@ -28,6 +28,15 @@ enum Color {
     White(String),
 }
 
+#[derive(Debug, Eq, PartialEq, EnumString)]
+#[strum(serialize_all = "UPPERCASE")]
+enum HttpMethod<'a> {
+    Get,
+    Post,
+    #[strum(default)]
+    Unrecognized(&'a str),
+}
+
 #[rustversion::since(1.34)]
 fn assert_from_str<'a, T>(a: T, from: &'a str)
 where
@@ -228,4 +237,11 @@ fn color_default_with_white() {
             panic!("Failed t o get  correct enum value {:?}", other);
         }
     }
+}
+
+#[test]
+fn http_method_from() {
+    assert_eq!(HttpMethod::Get, HttpMethod::from("GET"));
+    assert_eq!(HttpMethod::Post, HttpMethod::from("POST"));
+    assert_eq!(HttpMethod::Unrecognized("HEAD"), HttpMethod::from("HEAD"));
 }

--- a/strum_tests/tests/to_string.rs
+++ b/strum_tests/tests/to_string.rs
@@ -1,4 +1,4 @@
-#![allow(deprecated)]
+#![allow(deprecated, clippy::to_string_trait_impl)]
 
 use std::str::FromStr;
 use std::string::ToString;


### PR DESCRIPTION
1. Added support for enums that consuming strings they were parsed from. 
2. Changed behaviour to derive `From` trait instead of `TryFrom` when default variant is defined(`TryFrom`'ll be defined automatically with `Infallible` as error type).

> [!NOTE]  
> Maybe a breaking change, because error type of `TryFrom` trait is changed from `ParseError` to `Infallible`.
> Enums that consuming strings was leading to compiler error, so there's no breaking change in that part

Changes usage example:
```rust
#[derive(Debug, Eq, PartialEq, EnumString)]
#[strum(serialize_all = "UPPERCASE")]
enum HttpMethod<'a> {
    Get,
    Post,
    #[strum(default)]
    Unrecognized(&'a str),
}
```


