### PR TITLE
Fix disabled variants still appearing in variant names array

### DIFF
--- a/strum_macros/src/macros/enum_variant_names.rs
+++ b/strum_macros/src/macros/enum_variant_names.rs
@@ -20,10 +20,16 @@ pub fn enum_variant_names_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     let names = variants
         .iter()
-        .map(|v| {
-            let props = v.get_variant_properties()?;
-            Ok(props
-                .get_preferred_name(type_properties.case_style, type_properties.prefix.as_ref()))
+        .filter_map(|v| {
+            let properties = v.get_variant_properties();
+            match properties {
+                Ok(props) if props.disabled.is_none() => Some(Ok(props.get_preferred_name(
+                    type_properties.case_style,
+                    type_properties.prefix.as_ref(),
+                ))),
+                Ok(_) => None,
+                Err(error) => Some(Err(error)),
+            }
         })
         .collect::<syn::Result<Vec<LitStr>>>()?;
 

--- a/strum_tests/tests/enum_variant_names.rs
+++ b/strum_tests/tests/enum_variant_names.rs
@@ -36,6 +36,20 @@ fn variant_names_trait() {
 }
 
 #[test]
+fn disabled() {
+    #[allow(dead_code)]
+    #[derive(VariantNames)]
+    enum Color {
+        Red,
+        Blue,
+        #[strum(disabled)]
+        Yellow,
+    }
+
+    assert_eq!(Color::VARIANTS, &["Red", "Blue"]);
+}
+
+#[test]
 fn plain_kebab() {
     #[allow(dead_code)]
     #[derive(VariantNames)]


### PR DESCRIPTION
This PR resolves #244 

It includes the following changes so far:
- Test to check for this issue when using the macro a65a225db6f43a69e798b046f2e0d33dea73b9da
- Fix to make sure the generated VARIANTS array only contains variants which are not disabled 8444b6d51a349cff6bc70037a771ba5336912d73