### PR TITLE
Inline generated functions

### DIFF
--- a/strum_macros/src/macros/enum_discriminants.rs
+++ b/strum_macros/src/macros/enum_discriminants.rs
@@ -133,6 +133,7 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let impl_from = quote! {
         impl #impl_generics ::core::convert::From< #name #ty_generics > for #discriminants_name #where_clause {
+            #[inline]
             fn from(val: #name #ty_generics) -> #discriminants_name {
                 #from_fn_body
             }
@@ -150,6 +151,7 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
         quote! {
             impl #impl_generics ::core::convert::From< #enum_life #name #ty_generics > for #discriminants_name #where_clause {
+                #[inline]
                 fn from(val: #enum_life #name #ty_generics) -> #discriminants_name {
                     #from_fn_body
                 }
@@ -169,6 +171,7 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         impl #impl_generics #strum_module_path::IntoDiscriminant for #name #ty_generics #where_clause {
             type Discriminant = #discriminants_name;
 
+            #[inline]
             fn discriminant(&self) -> Self::Discriminant {
                 <Self::Discriminant as ::core::convert::From<&Self>>::from(self)
             }

--- a/strum_macros/src/macros/enum_iter.rs
+++ b/strum_macros/src/macros/enum_iter.rs
@@ -100,6 +100,8 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
         impl #impl_generics #strum_module_path::IntoEnumIterator for #name #ty_generics #where_clause {
             type Iterator = #iter_name #ty_generics;
+
+            #[inline]
             fn iter() -> #iter_name #ty_generics {
                 #iter_name {
                     idx: 0,
@@ -112,15 +114,18 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         impl #impl_generics Iterator for #iter_name #ty_generics #where_clause {
             type Item = #name #ty_generics;
 
+            #[inline]
             fn next(&mut self) -> ::core::option::Option<<Self as Iterator>::Item> {
                 self.nth(0)
             }
 
+            #[inline]
             fn size_hint(&self) -> (usize, ::core::option::Option<usize>) {
                 let t = if self.idx + self.back_idx >= #variant_count { 0 } else { #variant_count - self.idx - self.back_idx };
                 (t, Some(t))
             }
 
+            #[inline]
             fn nth(&mut self, n: usize) -> ::core::option::Option<<Self as Iterator>::Item> {
                 let idx = self.idx + n + 1;
                 if idx + self.back_idx > #variant_count {
@@ -137,12 +142,14 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         }
 
         impl #impl_generics ExactSizeIterator for #iter_name #ty_generics #where_clause {
+            #[inline]
             fn len(&self) -> usize {
                 self.size_hint().0
             }
         }
 
         impl #impl_generics DoubleEndedIterator for #iter_name #ty_generics #where_clause {
+            #[inline]
             fn next_back(&mut self) -> ::core::option::Option<<Self as Iterator>::Item> {
                 let back_idx = self.back_idx + 1;
 
@@ -162,6 +169,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         impl #impl_generics ::core::iter::FusedIterator for #iter_name #ty_generics #where_clause { }
 
         impl #impl_generics Clone for #iter_name #ty_generics #where_clause {
+            #[inline]
             fn clone(&self) -> #iter_name #ty_generics {
                 #iter_name {
                     idx: self.idx,

--- a/strum_macros/src/macros/enum_messages.rs
+++ b/strum_macros/src/macros/enum_messages.rs
@@ -113,24 +113,28 @@ pub fn enum_message_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         impl #impl_generics #strum_module_path::EnumMessage for #name #ty_generics #where_clause {
+            #[inline]
             fn get_message(&self) -> ::core::option::Option<&'static str> {
                 match self {
                     #(#arms),*
                 }
             }
 
+            #[inline]
             fn get_detailed_message(&self) -> ::core::option::Option<&'static str> {
                 match self {
                     #(#detailed_arms),*
                 }
             }
 
+            #[inline]
             fn get_documentation(&self) -> ::core::option::Option<&'static str> {
                 match self {
                     #(#documentation_arms),*
                 }
             }
 
+            #[inline]
             fn get_serializations(&self) -> &'static [&'static str] {
                 match self {
                     #(#serializations),*

--- a/strum_macros/src/macros/enum_properties.rs
+++ b/strum_macros/src/macros/enum_properties.rs
@@ -51,6 +51,7 @@ pub fn enum_properties_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         impl #impl_generics #strum_module_path::EnumProperty for #name #ty_generics #where_clause {
+            #[inline]
             fn get_str(&self, prop: &str) -> ::core::option::Option<&'static str> {
                 match self {
                     #(#arms),*

--- a/strum_macros/src/macros/enum_table.rs
+++ b/strum_macros/src/macros/enum_table.rs
@@ -133,6 +133,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
         impl<T> #table_name<T> {
             #[doc = #doc_new]
+            #[inline]
             #vis fn new(
                 #(#snake_idents: T,)*
             ) -> #table_name<T> {
@@ -142,6 +143,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
 
             #[doc = #doc_closure]
+            #[inline]
             #vis fn from_closure<F: Fn(#name)->T>(func: F) -> #table_name<T> {
               #table_name {
                 #(#closure_fields)*
@@ -149,6 +151,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
 
             #[doc = #doc_transform]
+            #[inline]
             #vis fn transform<U, F: Fn(#name, &T)->U>(&self, func: F) -> #table_name<U> {
               #table_name {
                 #(#transform_fields)*
@@ -160,6 +163,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         impl<T> ::core::ops::Index<#name> for #table_name<T> {
             type Output = T;
 
+            #[inline]
             fn index(&self, idx: #name) -> &T {
                 match idx {
                     #(#get_matches)*
@@ -169,6 +173,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         }
 
         impl<T> ::core::ops::IndexMut<#name> for #table_name<T> {
+            #[inline]
             fn index_mut(&mut self, idx: #name) -> &mut T {
                 match idx {
                     #(#get_matches_mut)*
@@ -179,6 +184,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
         impl<T> #table_name<::core::option::Option<T>> {
             #[doc = #doc_option_all]
+            #[inline]
             #vis fn all(self) -> ::core::option::Option<#table_name<T>> {
                 if let #table_name {
                     #(#snake_idents: ::core::option::Option::Some(#snake_idents),)*
@@ -194,6 +200,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
         impl<T, E> #table_name<::core::result::Result<T, E>> {
             #[doc = #doc_result_all_ok]
+            #[inline]
             #vis fn all_ok(self) -> ::core::result::Result<#table_name<T>, E> {
                 ::core::result::Result::Ok(#table_name {
                     #(#snake_idents: self.#snake_idents?,)*

--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -113,6 +113,7 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         #[allow(clippy::use_self)]
         impl #impl_generics #name #ty_generics #where_clause {
             #[doc = "Try to create [Self] from the raw representation"]
+            #[inline]
             #vis #const_if_possible fn from_repr(discriminant: #discriminant_type) -> Option<#name #ty_generics> {
                 #(#constant_defs)*
                 match discriminant {

--- a/strum_macros/src/macros/strings/as_ref_str.rs
+++ b/strum_macros/src/macros/strings/as_ref_str.rs
@@ -55,6 +55,7 @@ pub fn as_ref_str_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let arms = get_arms(ast)?;
     Ok(quote! {
         impl #impl_generics ::core::convert::AsRef<str> for #name #ty_generics #where_clause {
+            #[inline]
             fn as_ref(&self) -> &str {
                 match *self {
                     #(#arms),*
@@ -92,6 +93,7 @@ pub fn as_static_str_inner(
     Ok(match trait_variant {
         GenerateTraitVariant::AsStaticStr => quote! {
             impl #impl_generics #strum_module_path::AsStaticRef<str> for #name #ty_generics #where_clause {
+                #[inline]
                 fn as_static(&self) -> &'static str {
                     match *self {
                         #(#arms),*
@@ -101,6 +103,7 @@ pub fn as_static_str_inner(
         },
         GenerateTraitVariant::From => quote! {
             impl #impl_generics ::core::convert::From<#name #ty_generics> for &'static str #where_clause {
+                #[inline]
                 fn from(x: #name #ty_generics) -> &'static str {
                     match x {
                         #(#arms2),*
@@ -108,6 +111,7 @@ pub fn as_static_str_inner(
                 }
             }
             impl #impl_generics2 ::core::convert::From<&'_derivative_strum #name #ty_generics> for &'static str #where_clause {
+                #[inline]
                 fn from(x: &'_derivative_strum #name #ty_generics) -> &'static str {
                     match *x {
                         #(#arms3),*

--- a/strum_macros/src/macros/strings/from_string.rs
+++ b/strum_macros/src/macros/strings/from_string.rs
@@ -147,6 +147,8 @@ pub fn from_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         #[allow(clippy::use_self)]
         impl #impl_generics ::core::str::FromStr for #name #ty_generics #where_clause {
             type Err = #strum_module_path::ParseError;
+
+            #[inline]
             fn from_str(s: &str) -> ::core::result::Result< #name #ty_generics , <Self as ::core::str::FromStr>::Err> {
                 #phf_body
                 #standard_match_body
@@ -190,6 +192,8 @@ fn try_from_str(
         #[allow(clippy::use_self)]
         impl #impl_generics ::core::convert::TryFrom<&str> for #name #ty_generics #where_clause {
             type Error = #strum_module_path::ParseError;
+
+            #[inline]
             fn try_from(s: &str) -> ::core::result::Result< #name #ty_generics , <Self as ::core::convert::TryFrom<&str>>::Error> {
                 ::core::str::FromStr::from_str(s)
             }


### PR DESCRIPTION
This results in a 3.08% performance increase in one of my real life workloads. I was using the `EnumIter` expansion, but there's no reason any of the other expansions shouldn't have the attribute (except formatting functions, as inlining those is generally bad practice, especially error displaying and debug-formatting). For iterators especially, and even more so in a hot hot loop like in my case, not inlining the iterator can be devastating. Note that not even fat LTO saved me in this case which I'm already using.