### PR TITLE
Implement `get_int`/`get_bool` for properties

### DIFF
--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -182,7 +182,7 @@ pub trait EnumMessage {
 /// ```
 pub trait EnumProperty {
     fn get_str(&self, prop: &str) -> Option<&'static str>;
-    fn get_int(&self, _prop: &str) -> Option<usize> {
+    fn get_int(&self, _prop: &str) -> Option<i64> {
         Option::None
     }
 

--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -155,9 +155,8 @@ pub trait EnumMessage {
 
 /// `EnumProperty` is a trait that makes it possible to store additional information
 /// with enum variants. This trait is designed to be used with the macro of the same
-/// name in the `strum_macros` crate. Currently, the only string literals are supported
-/// in attributes, the other methods will be implemented as additional attribute types
-/// become stabilized.
+/// name in the `strum_macros` crate. Currently, the string, integer and bool literals
+/// are supported in attributes.
 ///
 /// # Example
 ///
@@ -168,27 +167,24 @@ pub trait EnumMessage {
 ///
 /// #[derive(PartialEq, Eq, Debug, EnumProperty)]
 /// enum Class {
-///     #[strum(props(Teacher="Ms.Frizzle", Room="201"))]
+///     #[strum(props(Teacher="Ms.Frizzle", Room="201", students=16, mandatory=true))]
 ///     History,
 ///     #[strum(props(Teacher="Mr.Smith"))]
-///     #[strum(props(Room="103"))]
+///     #[strum(props(Room="103", students=10))]
 ///     Mathematics,
-///     #[strum(props(Time="2:30"))]
+///     #[strum(props(Time="2:30", mandatory=true))]
 ///     Science,
 /// }
 ///
 /// let history = Class::History;
 /// assert_eq!("Ms.Frizzle", history.get_str("Teacher").unwrap());
+/// assert_eq!(16, history.get_int("students").unwrap());
+/// assert!(history.get_bool("mandatory").unwrap());
 /// ```
 pub trait EnumProperty {
     fn get_str(&self, prop: &str) -> Option<&'static str>;
-    fn get_int(&self, _prop: &str) -> Option<i64> {
-        Option::None
-    }
-
-    fn get_bool(&self, _prop: &str) -> Option<bool> {
-        Option::None
-    }
+    fn get_int(&self, _prop: &str) -> Option<i64>;
+    fn get_bool(&self, _prop: &str) -> Option<bool>;
 }
 
 /// A cheap reference-to-reference conversion. Used to convert a value to a

--- a/strum_macros/src/helpers/metadata.rs
+++ b/strum_macros/src/helpers/metadata.rs
@@ -176,7 +176,7 @@ pub enum VariantMeta {
     },
     Props {
         kw: kw::props,
-        props: Vec<(LitStr, LitStr)>,
+        props: Vec<(LitStr, Lit)>,
     },
 }
 
@@ -239,7 +239,7 @@ impl Parse for VariantMeta {
     }
 }
 
-struct Prop(Ident, LitStr);
+struct Prop(Ident, Lit);
 
 impl Parse for Prop {
     fn parse(input: ParseStream) -> syn::Result<Self> {

--- a/strum_macros/src/helpers/variant_props.rs
+++ b/strum_macros/src/helpers/variant_props.rs
@@ -1,5 +1,5 @@
 use std::default::Default;
-use syn::{Ident, LitStr, Variant};
+use syn::{Ident, Lit, LitStr, Variant};
 
 use super::case_style::{CaseStyle, CaseStyleHelpers};
 use super::metadata::{kw, VariantExt, VariantMeta};
@@ -18,7 +18,7 @@ pub struct StrumVariantProperties {
     pub message: Option<LitStr>,
     pub detailed_message: Option<LitStr>,
     pub documentation: Vec<LitStr>,
-    pub string_props: Vec<(LitStr, LitStr)>,
+    pub props: Vec<(LitStr, Lit)>,
     serialize: Vec<LitStr>,
     pub to_string: Option<LitStr>,
     ident: Option<Ident>,
@@ -143,7 +143,7 @@ impl HasStrumVariantProperties for Variant {
                     output.ascii_case_insensitive = Some(value);
                 }
                 VariantMeta::Props { props, .. } => {
-                    output.string_props.extend(props);
+                    output.props.extend(props);
                 }
             }
         }

--- a/strum_macros/src/macros/enum_properties.rs
+++ b/strum_macros/src/macros/enum_properties.rs
@@ -1,8 +1,16 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Fields};
+use syn::{Data, DeriveInput, Fields, Lit};
 
 use crate::helpers::{non_enum_error, HasStrumVariantProperties, HasTypeProperties};
+
+enum PropertyType {
+    String = 0,
+    Integer = 1,
+    Bool = 2,
+}
+
+const PROPERTY_TYPES: usize = 3;
 
 pub fn enum_properties_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
@@ -14,11 +22,12 @@ pub fn enum_properties_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let type_properties = ast.get_type_properties()?;
     let strum_module_path = type_properties.crate_module_path();
 
-    let mut arms = Vec::new();
+    let mut built_arms: [Vec<TokenStream>; 3] = Default::default();
+
     for variant in variants {
         let ident = &variant.ident;
         let variant_properties = variant.get_variant_properties()?;
-        let mut string_arms = Vec::new();
+        let mut arms: [Vec<_>; 3] = Default::default();
         // But you can disable the messages.
         if variant_properties.disabled.is_some() {
             continue;
@@ -30,33 +39,66 @@ pub fn enum_properties_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             Fields::Named(..) => quote! { {..} },
         };
 
-        for (key, value) in variant_properties.string_props {
-            string_arms.push(quote! { #key => ::core::option::Option::Some( #value )});
+        for (key, value) in variant_properties.props {
+            let property_type = match value {
+                Lit::Str(..) => PropertyType::String,
+                Lit::Bool(..) => PropertyType::Bool,
+                Lit::Int(..) => PropertyType::Integer,
+                _ => todo!("TODO"),
+            };
+
+            arms[property_type as usize]
+                .push(quote! { #key => ::core::option::Option::Some( #value )});
         }
 
-        string_arms.push(quote! { _ => ::core::option::Option::None });
-
-        arms.push(quote! {
-            &#name::#ident #params => {
-                match prop {
-                    #(#string_arms),*
+        for i in 0..PROPERTY_TYPES {
+            arms[i].push(quote! { _ => ::core::option::Option::None });
+            let arms_as_string = &arms[i];
+            built_arms[i].push(quote! {
+                &#name::#ident #params => {
+                    match prop {
+                        #(#arms_as_string),*
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
-    if arms.len() < variants.len() {
-        arms.push(quote! { _ => ::core::option::Option::None });
+    for arms in built_arms.iter_mut() {
+        if arms.len() < variants.len() {
+            arms.push(quote! { _ => ::core::option::Option::None });
+        }
     }
+
+    let (built_string_arms, built_int_arms, built_bool_arms) = (
+        &built_arms[PropertyType::String as usize],
+        &built_arms[PropertyType::Integer as usize],
+        &built_arms[PropertyType::Bool as usize],
+    );
 
     Ok(quote! {
         impl #impl_generics #strum_module_path::EnumProperty for #name #ty_generics #where_clause {
             #[inline]
             fn get_str(&self, prop: &str) -> ::core::option::Option<&'static str> {
                 match self {
-                    #(#arms),*
+                    #(#built_string_arms),*
                 }
             }
+
+            #[inline]
+            fn get_int(&self, prop: &str) -> ::core::option::Option<i64> {
+                match self {
+                    #(#built_int_arms),*
+                }
+            }
+
+            #[inline]
+            fn get_bool(&self, prop: &str) -> ::core::option::Option<bool> {
+                match self {
+                    #(#built_bool_arms),*
+                }
+            }
+
         }
     })
 }

--- a/strum_tests/tests/enum_props.rs
+++ b/strum_tests/tests/enum_props.rs
@@ -47,3 +47,30 @@ fn crate_module_path_test() {
     let a = Test::A;
     assert_eq!("value", a.get_str("key").unwrap());
 }
+
+#[derive(Debug, EnumProperty)]
+enum TestGet {
+    #[strum(props(weight = 42, flat = true, big = false))]
+    A,
+    #[strum(props(weight = -42, flat = false))]
+    B,
+    C,
+}
+
+#[test]
+fn get_bool_test() {
+    const BOOL_KEY: &str = "flat";
+    assert_eq!(Some(true), TestGet::A.get_bool(BOOL_KEY));
+    assert_eq!(Some(false), TestGet::B.get_bool(BOOL_KEY));
+    assert_eq!(None, TestGet::C.get_bool(BOOL_KEY));
+    assert_eq!(None, TestGet::A.get_bool("weight"));
+}
+
+#[test]
+fn get_int_test() {
+    const INT_KEY: &str = "weight";
+    assert_eq!(Some(42), TestGet::A.get_int(INT_KEY));
+    assert_eq!(Some(-42), TestGet::B.get_int(INT_KEY));
+    assert_eq!(None, TestGet::C.get_int(INT_KEY));
+    assert_eq!(None, TestGet::A.get_int("flat"));
+}


### PR DESCRIPTION
Fixes: #313

I am also suggesting to use `i64` as return type for `get_int` in order to cover also negative numbers.