### PR TITLE
Quality of life changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ members = [
     "strum_tests",
     "strum_nostd_tests"
 ]
- 
+resolver = "2"

--- a/strum/Cargo.toml
+++ b/strum/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "strum"
 version = "0.26.3"
-edition = "2018"
+edition = "2021"
 authors = ["Peter Glotfelty <peter.glotfelty@microsoft.com>"]
 license = "MIT"
 
@@ -13,10 +13,11 @@ documentation = "https://docs.rs/strum"
 homepage = "https://github.com/Peternator7/strum"
 repository = "https://github.com/Peternator7/strum"
 readme = "../README.md"
+rust-version = "1.66.1"
 
 [dependencies]
 strum_macros = { path = "../strum_macros", optional = true, version = "0.26.3" }
-phf = { version = "0.10", features = ["macros"], optional = true }
+phf = { version = "0.11.2", features = ["macros"], optional = true }
 
 [dev-dependencies]
 strum_macros = { path = "../strum_macros", version = "0.26" }

--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "strum_macros"
 version = "0.26.4"
-edition = "2018"
+edition = "2021"
 authors = ["Peter Glotfelty <peter.glotfelty@microsoft.com>"]
 license = "MIT"
 
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/strum"
 homepage = "https://github.com/Peternator7/strum"
 repository = "https://github.com/Peternator7/strum"
 readme = "../README.md"
+rust-version = "1.66.1"
 
 [lib]
 proc-macro = true

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -237,7 +237,8 @@ pub fn variant_names_deprecated(input: proc_macro::TokenStream) -> proc_macro::T
 /// meaning that the variants must not have any data.
 ///
 /// ```
-/// use strum::VariantArray;
+/// use strum::VariantArray as _;
+/// use strum_macros::VariantArray;
 ///
 /// #[derive(VariantArray, Debug, PartialEq, Eq)]
 /// enum Op {
@@ -830,8 +831,8 @@ pub fn enum_properties(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 /// ```
 /// // Bring trait into scope
 /// use std::str::FromStr;
-/// use strum::{IntoEnumIterator, EnumMessage};
-/// use strum_macros::{EnumDiscriminants, EnumIter, EnumString};
+/// use strum::{IntoEnumIterator, EnumMessage as _};
+/// use strum_macros::{EnumDiscriminants, EnumIter, EnumString, EnumMessage};
 ///
 /// #[derive(Debug)]
 /// struct NonDefault;

--- a/strum_nostd_tests/Cargo.toml
+++ b/strum_nostd_tests/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "strum_nostd_tests"
 version = "0.26.0"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
+rust-version = "1.66.1"
 
 [dependencies]
 strum = { path = "../strum", features = ["derive"] }

--- a/strum_tests/Cargo.toml
+++ b/strum_tests/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "strum_tests"
 version = "0.26.0"
-edition = "2018"
+edition = "2021"
 authors = ["Peter Glotfelty <peglotfe@microsoft.com>"]
+rust-version = "1.66.1"
 
 [features]
 default = []
@@ -11,10 +12,9 @@ test_phf = ["strum/phf"]
 [dependencies]
 strum = { path = "../strum", features = ["derive"] }
 strum_macros = { path = "../strum_macros", features = [] }
-clap = "=2.33.0"
+clap = "=4.2.7"
 enum_variant_type = "=0.2.0"
-structopt = "0.2.18"
-bitflags = "=1.2"
+structopt = "=0.3.26"
 
 [dev-dependencies]
 rustversion = "1.0"

--- a/strum_tests/tests/enum_variant_names.rs
+++ b/strum_tests/tests/enum_variant_names.rs
@@ -80,7 +80,7 @@ fn clap_and_structopt() {
         #[structopt(
             long = "color",
             default_value = "Color::Blue",
-            raw(possible_values = "Color::VARIANTS")
+            possible_values = Color::VARIANTS
         )]
         color: Color,
     }
@@ -99,11 +99,11 @@ fn clap_and_structopt() {
         &["red", "blue", "yellow", "rebecca-purple"]
     );
 
-    let _clap_example = clap::App::new("app").arg(
-        clap::Arg::with_name("color")
+    let _clap_example = clap::Command::new("app").arg(
+        clap::Arg::new("color")
             .long("color")
-            .possible_values(Color::VARIANTS)
-            .case_insensitive(true),
+            .value_names(Color::VARIANTS)
+            .ignore_case(true),
     );
 }
 


### PR DESCRIPTION
Upgrade the MSRV to 1.66.1: 1.66.0 was released two years ago on 15th of December 2022, and 1.66.1 is a point version released on the 10th of January 2023, only as a fix for a CVE.

Upgrade dependencies to the latest version that supports Rust v1.66.1: enum_variant_type wasn't upgraded as it will stop us from making sure that ::core is used in macros.

Remove unused dependencies: Bitflags wasn't used in the strum_tests crate.

Specify some options in the Cargo.toml files, such as the resolver version (set to 2), and the rust-version(s) for the included crates (set to 1.66.1).