### PR TITLE
deps: bumped phf to 0.11

### DIFF
--- a/strum/Cargo.toml
+++ b/strum/Cargo.toml
@@ -16,7 +16,7 @@ readme = "../README.md"
 
 [dependencies]
 strum_macros = { path = "../strum_macros", optional = true, version = "0.26.3" }
-phf = { version = "0.10", features = ["macros"], optional = true }
+phf = { version = "0.11", features = ["macros"], optional = true }
 
 [dev-dependencies]
 strum_macros = { path = "../strum_macros", version = "0.26" }


### PR DESCRIPTION
Happy New Year @Peternator7 !

phf 0.10 was released in Dec 3, 2021.

With strum's bumped MSRV, it can now use phf 0.11.3 which was released Jan 6, 2025.