### PR TITLE
Use asserts instead of println in Display docstrings

### DIFF
--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -154,10 +154,13 @@ pub fn from_string(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// let yellow = Color::Yellow;
 /// assert_eq!("Yellow", yellow.as_ref());
 /// // or for string formatting
-/// println!(
-///     "blue: {} green: {}",
-///     Color::Blue(10).as_ref(),
-///     Color::Green { range: 42 }.as_ref()
+/// assert_eq!(
+///    "blue: Blue green: Green",
+///    format!(
+///        "blue: {} green: {}",
+///        Color::Blue(10).as_ref(),
+///        Color::Green { range: 42 }.as_ref()
+///    )
 /// );
 ///
 /// // With prefix on all variants
@@ -412,10 +415,13 @@ pub fn to_string(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// let yellow = Color::Yellow;
 /// assert_eq!(String::from("Yellow"), yellow.to_string());
 /// // or for string formatting
-/// println!(
-///     "blue: {} green: {}",
-///     Color::Blue(10),
-///     Color::Green { range: 42 }
+/// assert_eq!(
+///    "blue: Blue green: Green",
+///    format!(
+///        "blue: {} green: {}",
+///        Color::Blue(10).as_ref(),
+///        Color::Green { range: 42 }.as_ref()
+///    )
 /// );
 /// // you can also use named fields in message
 /// let purple = Color::Purple { sat: 10 };

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -419,8 +419,8 @@ pub fn to_string(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///    "blue: Blue green: Green",
 ///    format!(
 ///        "blue: {} green: {}",
-///        Color::Blue(10).as_ref(),
-///        Color::Green { range: 42 }.as_ref()
+///        Color::Blue(10),
+///        Color::Green { range: 42 }
 ///    )
 /// );
 /// // you can also use named fields in message


### PR DESCRIPTION
I've recently discovered that I was using strum incorrectly assuming that content of variants will be printed. In 0.26 the content **can** be printed but as this is not the default, I've decided that it may still be beneficial to clarify in the docs what to expect from the default option.

To better convey the results and make sure the user expectations are set right, I propose to use `assert_eq` + `format` instead of `println` as the latter is not very informative without specifying what should be printed as a result.