### PR TITLE
Fix `Display` macro in `#![no_std]` programs

### DIFF
--- a/strum_macros/src/macros/strings/display.rs
+++ b/strum_macros/src/macros/strings/display.rs
@@ -94,7 +94,7 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
                         quote! {
                             #[allow(unused_variables)]
-                            #name::#ident #params => ::core::fmt::Display::fmt(&format!(#output, #args), f)
+                            #name::#ident #params => ::core::fmt::Display::fmt(&format_args!(#output, #args), f)
                         }
                     }
                 },


### PR DESCRIPTION
In `#[no_std]` `format!` does not exist, so the `to_string` helper was not usable.