### PR TITLE
Remove gnu toolchains from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,35 +64,6 @@ environment:
       target: i686-pc-windows-msvc
       #cargoflags: --features "unstable"
 
-### GNU Toolchains ###
-
-  # MSRC 64-bit GNU
-    - channel: 1.66.1
-      target: x86_64-pc-windows-gnu
-  # MSRC 32-bit GNU
-    - channel: 1.66.1
-      target: i686-pc-windows-gnu
-  # Stable 64-bit GNU
-    - channel: stable
-      target: x86_64-pc-windows-gnu
-  # Stable 32-bit GNU
-    - channel: stable
-      target: i686-pc-windows-gnu
-  # Beta 64-bit GNU
-    - channel: beta
-      target: x86_64-pc-windows-gnu
-  # Beta 32-bit GNU
-    - channel: beta
-      target: i686-pc-windows-gnu
-  # Nightly 64-bit GNU
-    - channel: nightly
-      target: x86_64-pc-windows-gnu
-      #cargoflags: --features "unstable"
-  # Nightly 32-bit GNU
-    - channel: nightly
-      target: i686-pc-windows-gnu
-      #cargoflags: --features "unstable"
-
 ### Allowed failures ###
 
 # See Appveyor documentation for specific details. In short, place any channel or targets you wish


### PR DESCRIPTION
They always fail, and this crate doesn't really do anything OS/toolchain dependent so it's not likely to catch anything anyway.