### PR TITLE
Fix docsrs build error regarding IntoDiscriminant trait

### DIFF
--- a/strum/src/lib.rs
+++ b/strum/src/lib.rs
@@ -253,7 +253,7 @@ DocumentMacroRexports! {
     AsRefStr,
     Display,
     EnumCount,
-    IntoDiscriminant,
+    EnumDiscriminants,
     EnumIter,
     EnumMessage,
     EnumProperty,


### PR DESCRIPTION
The [current build on docs.rs](https://docs.rs/crate/strum/0.27.0/builds/1725115) is failing.
This is due to the inclusion of `IntoDiscriminant` as a macro re-export. 

This is a compilation error because `IntoDiscriminant` is not in the location expected by the `DocumentMacroRexports` macro. It's also semantically suspect as `IntoDiscriminant` is also not a macro, so it seems strange for it to be included in the list more generally.

The current PR resolves this by renaming `IntoDiscriminant` back to `EnumDiscriminants`, effectively reverting a change introduced in [PR377](https://github.com/Peternator7/strum/pull/377). Perhaps @vpochapuis can comment on whether this is a good idea and if there are alternative approachs to resolving the issue. 

Running `cargo +nightly rustdoc --features derive -- --cfg docsrs` in the `strum` directory is sufficient to reproduce the build failure, and confirms that current commit resolves the error. It could also be worth adding this to CI to ensure that docs builds don't fail in the future?

Aside: It would also be nice to somehow resolve the docs warnings of `EnumDiscriminants` not being available when compiling without the `derive` feature, and not sure if the `IntoDiscriminant` trait should be gated to prevent this, but I'm leaving this alone for the meantime as it's not really the issue at hand.

