### PR TITLE
Update docs to actually include new features

### DIFF
--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -54,6 +54,12 @@ fn debug_print_generated(ast: &DeriveInput, toks: &TokenStream) {
 /// If you have a large enum, you may want to consider using the `use_phf` attribute here. It leverages
 /// perfect hash functions to parse much quicker than a standard `match`. (MSRV 1.46)
 ///
+/// The default error type is `strum::ParseError`. This can be overriden by applying both the
+/// `parse_err_ty` and `parse_err_fn` attributes at the type level.  `parse_error_fn` should be a
+/// function that accepts an `&str` and returns the type `parse_error_ty`. See 
+/// [this test case](https://github.com/Peternator7/strum/blob/9db3c4dc9b6f585aeb9f5f15f9cc18b6cf4fd780/strum_tests/tests/from_str.rs#L233)
+/// for an example.
+///
 /// # Example how to use `EnumString`
 /// ```
 /// use std::str::FromStr;


### PR DESCRIPTION
The new `parse_error_*` attributes didn't make it into the docs. Here's an update.