### PR TITLE
Fix warnings in tests from variants 

### DIFF
--- a/strum_macros/src/macros/strings/as_ref_str.rs
+++ b/strum_macros/src/macros/strings/as_ref_str.rs
@@ -93,7 +93,7 @@ pub fn as_static_str_inner(
 ) -> syn::Result<TokenStream> {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-    let arms = get_arms(ast, |tok| {
+    let arms = &get_arms(ast, |tok| {
         quote! { ::core::convert::From::from(#tok) }
     })?;
 
@@ -107,8 +107,6 @@ pub fn as_static_str_inner(
             parse_quote!('_derivative_strum),
         )));
     let (impl_generics2, _, _) = generics.split_for_impl();
-    let arms2 = arms.clone();
-    let arms3 = arms.clone();
 
     Ok(match trait_variant {
         GenerateTraitVariant::AsStaticStr => quote! {
@@ -126,7 +124,7 @@ pub fn as_static_str_inner(
                 #[inline]
                 fn from(x: #name #ty_generics) -> &'static str {
                     match x {
-                        #(#arms2),*
+                        #(#arms),*
                     }
                 }
             }
@@ -134,7 +132,7 @@ pub fn as_static_str_inner(
                 #[inline]
                 fn from(x: &'_derivative_strum #name #ty_generics) -> &'static str {
                     match *x {
-                        #(#arms3),*
+                        #(#arms),*
                     }
                 }
             }
@@ -143,7 +141,7 @@ pub fn as_static_str_inner(
             impl #impl_generics #name #ty_generics #where_clause {
                 pub const fn into_str(&self) -> &'static str {
                     match self {
-                        #(#arms3),*
+                        #(#arms),*
                     }
                 }
             }
@@ -151,7 +149,7 @@ pub fn as_static_str_inner(
             impl #impl_generics ::core::convert::From<#name #ty_generics> for &'static str #where_clause {
                 fn from(x: #name #ty_generics) -> &'static str {
                     match x {
-                        #(#arms2),*
+                        #(#arms),*
                     }
                 }
             }

--- a/strum_tests/tests/as_ref_str.rs
+++ b/strum_tests/tests/as_ref_str.rs
@@ -64,6 +64,7 @@ fn as_fuchsia_str() {
 #[derive(IntoStaticStr)]
 enum Foo<'a> {
     A,
+    #[allow(dead_code)]
     C(&'a i32),
 }
 
@@ -71,6 +72,7 @@ enum Foo<'a> {
 enum Boo<'a, T> {
     A(T),
     B,
+    #[allow(dead_code)]
     C(&'a i32),
 }
 
@@ -81,6 +83,7 @@ where
 {
     A(T),
     B,
+    #[allow(dead_code)]
     C(&'a i32),
 }
 
@@ -144,6 +147,7 @@ where
 {
     A(T),
     B,
+    #[allow(dead_code)]
     C(&'a i32),
     #[strum(serialize = "Dark")]
     D,
@@ -151,6 +155,7 @@ where
     G,
     #[strum(serialize = "b", to_string = "blue")]
     Blue {
+        #[allow(dead_code)]
         hue: usize,
     },
     #[strum(serialize = "y", serialize = "yellow")]
@@ -161,6 +166,7 @@ where
 #[strum(const_into_str)]
 enum Baz<'a, T> {
     A(T),
+    #[allow(dead_code)]
     C(&'a i32),
 }
 
@@ -170,6 +176,7 @@ enum Baz<'a, T> {
 enum BrightnessConst {
     DarkBlack,
     Dim {
+        #[allow(dead_code)]
         glow: usize,
     },
     #[strum(serialize = "Bright")]

--- a/strum_tests/tests/enum_is.rs
+++ b/strum_tests/tests/enum_is.rs
@@ -3,11 +3,13 @@ use strum::EnumIs;
 
 mod core {} // ensure macros call `::core`
 #[derive(EnumIs)]
+#[allow(dead_code)]
 enum LifeTimeTest<'a> {
     One(Cow<'a, str>),
     Two(&'a str),
 }
 #[derive(EnumIs)]
+#[allow(dead_code)]
 enum Foo {
     Unit,
     Named0 {},

--- a/strum_tests/tests/enum_variant_table.rs
+++ b/strum_tests/tests/enum_variant_table.rs
@@ -1,6 +1,7 @@
 use strum::EnumTable;
 
 #[derive(EnumTable)]
+#[allow(dead_code)]
 enum Color {
     Red,
     Yellow,
@@ -15,6 +16,7 @@ enum Color {
 // even though this isn't used, it needs to be a test
 // because if it doesn't compile, enum variants that conflict with keywords won't work
 #[derive(EnumTable)]
+#[allow(dead_code)]
 enum Keyword {
     Const,
 }

--- a/strum_tests/tests/from_repr.rs
+++ b/strum_tests/tests/from_repr.rs
@@ -44,6 +44,7 @@ fn const_test() {
 fn crate_module_path_test() {
     pub mod nested {
         pub mod module {
+            #[allow(unused_imports)]
             pub use strum;
         }
     }


### PR DESCRIPTION
The test have variants on enums that need to exist to ensure we don't error on specific code patterns but we don't actually generate. This PR suppresses some warnings that come from unused variants.