### PR TITLE
Fix an incorrect refactor on the unifying of the "transparent" code

### DIFF
--- a/strum/src/additional_attributes.rs
+++ b/strum/src/additional_attributes.rs
@@ -76,7 +76,9 @@
 //!
 //! - `transparent`: Signals that the inner field's implementation should be used, instead of generating
 //!    one for this variant. Only applicable to enum variants with a single field. Compatible with the
-//!    `AsRefStr`, `Display` and `IntoStaticStr` derive macros.
+//!    `AsRefStr`, `Display` and `IntoStaticStr` derive macros. Note that `IntoStaticStr` has a few restrictions,
+//!    the value must be `'static` and `const_into_str` is not supported in combination with `transparent` b/c
+//!    transparent relies on a call on `From::from(variant)`.
 //!
 //! - `disabled`: removes variant from generated code.
 //!

--- a/strum_macros/src/macros/strings/display.rs
+++ b/strum_macros/src/macros/strings/display.rs
@@ -27,7 +27,7 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
         if let Some(..) = variant_properties.transparent {
             let arm = super::extract_single_field_variant_and_then(name, variant, |tok| {
-                quote! { ::core::fmt::Display::fmt(#tok, f)}
+                quote! { ::core::fmt::Display::fmt(#tok, f) }
             })
             .map_err(|_| non_single_field_variant_error("transparent"))?;
 

--- a/strum_macros/src/macros/strings/mod.rs
+++ b/strum_macros/src/macros/strings/mod.rs
@@ -26,7 +26,8 @@ where
             quote! { (ref #pat) => #ret_val }
         }
         Fields::Named(f) if f.named.len() == 1 => {
-            let ident = &quote! { f.named.last().unwrap().ident.as_ref().unwrap() };
+            let ident = f.named.last().unwrap().ident.as_ref().unwrap();
+            let ident = &quote! { #ident };
             let ret_val = return_val_fn(ident);
             quote! { {ref #ident} => #ret_val }
         }

--- a/strum_tests/tests/as_ref_str.rs
+++ b/strum_tests/tests/as_ref_str.rs
@@ -122,6 +122,10 @@ enum Brightness {
     },
     #[strum(serialize = "Bright")]
     BrightWhite,
+    #[strum(transparent)]
+    Gray(&'static str),
+    #[strum(transparent)]
+    Grey { inner: &'static str }
 }
 
 #[test]
@@ -137,6 +141,8 @@ fn brightness_serialize_all() {
     assert_eq!("dark_black", <&'static str>::from(Brightness::DarkBlack));
     assert_eq!("dim", <&'static str>::from(Brightness::Dim { glow: 0 }));
     assert_eq!("Bright", <&'static str>::from(Brightness::BrightWhite));
+    assert_eq!("Gray", <&'static str>::from(Brightness::Gray("Gray")));
+    assert_eq!("Grey", <&'static str>::from(Brightness::Grey { inner: "Grey" }));
 }
 
 #[derive(IntoStaticStr)]

--- a/strum_tests/tests/as_ref_str.rs
+++ b/strum_tests/tests/as_ref_str.rs
@@ -30,6 +30,8 @@ enum Color {
     Green(String),
     #[strum(transparent)]
     Inner(InnerColor),
+    #[strum(transparent)]
+    InnerField { inner: InnerColor },
 }
 
 #[test]
@@ -59,6 +61,7 @@ fn as_green_str() {
 #[test]
 fn as_fuchsia_str() {
     assert_eq!("Purple", (Color::Inner(InnerColor::Purple)).as_ref());
+    assert_eq!("Purple", (Color::InnerField { inner: InnerColor::Purple }).as_ref());
 }
 
 #[derive(IntoStaticStr)]

--- a/strum_tests/tests/display.rs
+++ b/strum_tests/tests/display.rs
@@ -157,6 +157,9 @@ fn non_string_default_to_string() {
 enum TransparentString {
     #[strum(transparent)]
     Something(String),
+
+    #[strum(transparent)]
+    SomethingNamed { my_field: String },
 }
 
 #[test]
@@ -166,6 +169,19 @@ fn transparent_string() {
         format!(
             "{}",
             TransparentString::Something("string in here".to_owned())
+        )
+    );
+}
+
+#[test]
+fn transparent_string_named_field() {
+    assert_eq!(
+        String::from("string in here"),
+        format!(
+            "{}",
+            TransparentString::SomethingNamed {
+                my_field: String::from("string in here")
+            }
         )
     );
 }

--- a/strum_tests/tests/from_str.rs
+++ b/strum_tests/tests/from_str.rs
@@ -28,6 +28,12 @@ enum Color {
     White(String),
 }
 
+#[derive(Debug, Eq, PartialEq, EnumString, strum::Display)]
+enum Color2 {
+    #[strum(default)]
+    Purple { inner: String }
+}
+
 #[rustversion::since(1.34)]
 fn assert_from_str<'a, T>(a: T, from: &'a str)
 where
@@ -72,6 +78,12 @@ fn color_to_string() {
 #[test]
 fn color_default() {
     assert_from_str(Color::Green(String::from("not found")), "not found");
+}
+
+#[test]
+fn color2_default() {
+    assert_from_str(Color2::Purple { inner: String::from("test") }, "test");
+    assert_eq!(String::from("test"), Color2::Purple { inner: String::from("test") }.to_string());
 }
 
 #[test]


### PR DESCRIPTION
During combining a few different code paths together, I combined a few lines into invalid generated code. This fixes that, and adds a few additional test cases to catch future changes as well.