### PR TITLE
Honor parse_err_ty attribute when the enum has a default variant

### DIFF
--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -55,10 +55,14 @@ fn debug_print_generated(ast: &DeriveInput, toks: &TokenStream) {
 /// perfect hash functions to parse much quicker than a standard `match`. (MSRV 1.46)
 ///
 /// The default error type is `strum::ParseError`. This can be overriden by applying both the
-/// `parse_err_ty` and `parse_err_fn` attributes at the type level.  `parse_error_fn` should be a
-/// function that accepts an `&str` and returns the type `parse_error_ty`. See
-/// [this test case](https://github.com/Peternator7/strum/blob/9db3c4dc9b6f585aeb9f5f15f9cc18b6cf4fd780/strum_tests/tests/from_str.rs#L233)
+/// `parse_err_ty` and `parse_err_fn` attributes at the type level.  `parse_err_fn` should be a
+/// function that accepts an `&str` and returns the type `parse_err_ty`. See [this test
+/// case](https://github.com/Peternator7/strum/blob/9db3c4dc9b6f585aeb9f5f15f9cc18b6cf4fd780/strum_tests/tests/from_str.rs#L233)
 /// for an example.
+///
+/// If the enum has a default variant (annotated with `#[strum(default)]`), then parsing is
+/// infallible. In that case, `parse_err_fn` need not exist (it will never be called) and
+/// `parse_err_ty` can be safely set to [`std::convert::Infallible`].
 ///
 /// # Example how to use `EnumString`
 /// ```

--- a/strum_tests/tests/from_str.rs
+++ b/strum_tests/tests/from_str.rs
@@ -274,3 +274,29 @@ fn case_custom_parse_error() {
         r.unwrap_err()
     );
 }
+
+#[derive(Debug, EnumString, Eq, PartialEq)]
+#[strum(
+    parse_err_fn = not_needed_parsing_is_infallible,
+    parse_err_ty = std::convert::Infallible
+)]
+enum CaseCustomInfallibleParsingWithDefaultEnum {
+    #[strum(serialize = "foo")]
+    Foo,
+    #[strum(serialize = "bar")]
+    Bar,
+    #[strum(default)]
+    Unknown(String),
+}
+
+#[test]
+fn case_custom_infallible_parsing_with_default() {
+    let r = match "yellow".parse::<CaseCustomInfallibleParsingWithDefaultEnum>() {
+        Ok(r) => r,
+        Err(never) => match never {},
+    };
+    assert_eq!(
+        CaseCustomInfallibleParsingWithDefaultEnum::Unknown("yellow".to_string()),
+        r
+    );
+}


### PR DESCRIPTION
Currently, the `EnumString` ignore the `parse_err_ty` attribute for any enum with a `#[strum(default)]` variant. Fix it and add a unit test to validate the behavior.

Fixes https://github.com/Peternator7/strum/issues/430