### PR TITLE
Support infallible EnumString for enums with a default variant

### DIFF
--- a/strum_macros/src/helpers/metadata.rs
+++ b/strum_macros/src/helpers/metadata.rs
@@ -19,6 +19,7 @@ pub mod kw {
     custom_keyword!(const_into_str);
     custom_keyword!(use_phf);
     custom_keyword!(prefix);
+    custom_keyword!(parse_infallible);
     custom_keyword!(parse_err_ty);
     custom_keyword!(parse_err_fn);
 
@@ -64,6 +65,7 @@ pub enum EnumMeta {
         kw: kw::parse_err_fn,
         path: Path,
     },
+    ParseInfallible(kw::parse_infallible),
     ConstIntoStr(kw::const_into_str),
 }
 
@@ -104,6 +106,8 @@ impl Parse for EnumMeta {
             input.parse::<Token![=]>()?;
             let path: Path = input.parse()?;
             Ok(EnumMeta::ParseErrFn { kw, path })
+        } else if lookahead.peek(kw::parse_infallible) {
+            Ok(EnumMeta::ParseInfallible(input.parse()?))
         } else if lookahead.peek(kw::const_into_str) {
             Ok(EnumMeta::ConstIntoStr(input.parse()?))
         } else {

--- a/strum_macros/src/helpers/mod.rs
+++ b/strum_macros/src/helpers/mod.rs
@@ -20,6 +20,20 @@ pub fn missing_parse_err_attr_error() -> syn::Error {
     )
 }
 
+pub fn missing_default_attr_error() -> syn::Error {
+    syn::Error::new(
+        Span::call_site(),
+        "`parse_infallible` requires a default enum variant.",
+    )
+}
+
+pub fn incompatible_parse_attribute_error() -> syn::Error {
+    syn::Error::new(
+        Span::call_site(),
+        "`parse_err_ty` and `parse_err_fn` attributes are incompatible with `parse_infallible`.",
+    )
+}
+
 pub fn non_enum_error() -> syn::Error {
     syn::Error::new(Span::call_site(), "This macro only supports enums.")
 }

--- a/strum_macros/src/helpers/type_props.rs
+++ b/strum_macros/src/helpers/type_props.rs
@@ -15,6 +15,7 @@ pub trait HasTypeProperties {
 pub struct StrumTypeProperties {
     pub parse_err_ty: Option<Path>,
     pub parse_err_fn: Option<Path>,
+    pub parse_infallible: bool,
     pub case_style: Option<CaseStyle>,
     pub ascii_case_insensitive: bool,
     pub crate_module_path: Option<Path>,
@@ -38,6 +39,7 @@ impl HasTypeProperties for DeriveInput {
 
         let mut parse_err_ty_kw = None;
         let mut parse_err_fn_kw = None;
+        let mut parse_infallible_kw = None;
         let mut serialize_all_kw = None;
         let mut ascii_case_insensitive_kw = None;
         let mut use_phf_kw = None;
@@ -105,6 +107,14 @@ impl HasTypeProperties for DeriveInput {
 
                     parse_err_fn_kw = Some(kw);
                     output.parse_err_fn = Some(path);
+                }
+                EnumMeta::ParseInfallible(kw) => {
+                    if let Some(fst_kw) = parse_infallible_kw {
+                        return Err(occurrence_error(fst_kw, kw, "parse_infallible"));
+                    }
+
+                    parse_infallible_kw = Some(kw);
+                    output.parse_infallible = true;
                 }
                 EnumMeta::ConstIntoStr(kw) => {
                     if let Some(fst_kw) = const_into_str {

--- a/strum_tests/tests/from_str.rs
+++ b/strum_tests/tests/from_str.rs
@@ -242,6 +242,33 @@ fn color_default_with_white() {
     }
 }
 
+#[derive(Debug, EnumString, Eq, PartialEq)]
+#[strum(parse_infallible)]
+enum CaseInfallibleParsingWithDefaultEnum {
+    #[strum(serialize = "foo")]
+    Foo,
+    #[strum(serialize = "bar")]
+    Bar,
+    #[strum(default)]
+    Unknown(String),
+}
+
+#[test]
+fn case_infallible_parsing_with_default() {
+    assert_eq!(
+        CaseInfallibleParsingWithDefaultEnum::from("yellow"),
+        CaseInfallibleParsingWithDefaultEnum::Unknown("yellow".to_string()),
+    );
+    let r = match "yellow".parse::<CaseInfallibleParsingWithDefaultEnum>() {
+        Ok(r) => r,
+        Err(never) => match never {},
+    };
+    assert_eq!(
+        CaseInfallibleParsingWithDefaultEnum::Unknown("yellow".to_string()),
+        r
+    );
+}
+
 #[derive(Debug, EnumString)]
 #[strum(
     parse_err_fn = some_enum_not_found_err,

--- a/strum_tests/tests/phf.rs
+++ b/strum_tests/tests/phf.rs
@@ -33,3 +33,22 @@ fn from_str_with_phf_big() {
     }
     assert_eq!("vAr2".parse::<Enum>().unwrap(), Enum::Var2);
 }
+
+#[cfg(feature = "test_phf")]
+#[test]
+fn infallible_from_str_with_phf() {
+    // This tests PHF with infallible parsing
+    #[derive(Debug, PartialEq, Eq, Clone, strum::EnumString)]
+    #[strum(use_phf, parse_infallible)]
+    enum InfallibleColor {
+        #[strum(ascii_case_insensitive)]
+        Blue,
+        Red,
+        #[strum(default)]
+        Unknown(String),
+    }
+    assert_eq!(InfallibleColor::from("Red"), InfallibleColor::Red);
+    assert_eq!(InfallibleColor::from("bLuE"), InfallibleColor::Blue);
+    assert_eq!("Red".parse(), Ok(InfallibleColor::Red));
+    assert_eq!("bLuE".parse(), Ok(InfallibleColor::Blue));
+}


### PR DESCRIPTION
Any enum with a `#[strum(default)]` variant has infallible parsing in practice, but the compiler does not know this because the error type is still `strum::ParseError`.

This PR proposes a non-breaking change to address the issue: Define a new type-level attribute `parse_infallible`, which instructs `EnumString` to use `std::convert::Infallible` for `FromStr::Err`, and to derive `From<&str>` (always) instead of `TryFrom<&str>` (1.34+). This allows e.g.
```rust
let variant = MyInfallibleEnum::from("some_unknown_variant")
```
and (in 1.82+)
```rust
let Ok(variant) = MyInfallibleEnum::from_str("some_unknown_variant");
```

Existing `EnumString` derivations remain unchanged unless the user adds the `parse_infallible` attribute. As a future breaking change, we could start inferring `parse_infallible` automatically even for enums that do not carry the annotation. If a breaking change is immediately acceptable, we don't need to define the new attribute at all, and this PR becomes simpler.

NOTE: `TryFrom` is still available (for 1.34+) with `parse_infallible`, because the `From<&str>` derived by `EnumString` activates a blanket implementation of reverse [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html#impl-Into%3CU%3E-for-T), which in turn activates a blanket implementation of [`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html#impl-TryFrom%3CU%3E-for-T).

Also update docs and add new unit tests that exercise infallible parsing for both normal and PHF enums.

Fixes https://github.com/Peternator7/strum/issues/307