### PR TITLE
Add `#[automatically_derived]` to the `impl`s

### DIFF
--- a/strum_macros/src/macros/enum_count.rs
+++ b/strum_macros/src/macros/enum_count.rs
@@ -27,6 +27,7 @@ pub(crate) fn enum_count_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         // Implementation
+        #[automatically_derived]
         impl #impl_generics #strum_module_path::EnumCount for #name #ty_generics #where_clause {
             const COUNT: usize = #n;
         }

--- a/strum_macros/src/macros/enum_discriminants.rs
+++ b/strum_macros/src/macros/enum_discriminants.rs
@@ -140,6 +140,7 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let impl_from = quote! {
+        #[automatically_derived]
         impl #impl_generics ::core::convert::From< #name #ty_generics > for #discriminants_name #where_clause {
             #[inline]
             fn from(val: #name #ty_generics) -> #discriminants_name {
@@ -158,6 +159,7 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         let (impl_generics, _, _) = generics.split_for_impl();
 
         quote! {
+            #[automatically_derived]
             impl #impl_generics ::core::convert::From< #enum_life #name #ty_generics > for #discriminants_name #where_clause {
                 #[inline]
                 fn from(val: #enum_life #name #ty_generics) -> #discriminants_name {
@@ -171,6 +173,7 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let impl_into_discriminant = match type_properties.discriminant_vis {
         // If the visibilty is unspecified or `pub` then we implement IntoDiscriminant
         None | Some(syn::Visibility::Public(..)) => quote! {
+            #[automatically_derived]
             impl #impl_generics #strum_module_path::IntoDiscriminant for #name #ty_generics #where_clause {
                 type Discriminant = #discriminants_name;
 

--- a/strum_macros/src/macros/enum_is.rs
+++ b/strum_macros/src/macros/enum_is.rs
@@ -39,6 +39,7 @@ pub fn enum_is_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         .collect();
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #enum_name  #ty_generics #where_clause {
             #(#variants)*
         }

--- a/strum_macros/src/macros/enum_iter.rs
+++ b/strum_macros/src/macros/enum_iter.rs
@@ -80,6 +80,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             marker: ::core::marker::PhantomData #phantom_data,
         }
 
+        #[automatically_derived]
         impl #impl_generics ::core::fmt::Debug for #iter_name #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 // We don't know if the variants implement debug themselves so the only thing we
@@ -90,6 +91,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics #iter_name #ty_generics #where_clause {
             fn get(&self, idx: usize) -> ::core::option::Option<#name #ty_generics> {
                 match idx {
@@ -98,6 +100,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics #strum_module_path::IntoEnumIterator for #name #ty_generics #where_clause {
             type Iterator = #iter_name #ty_generics;
 
@@ -111,6 +114,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics Iterator for #iter_name #ty_generics #where_clause {
             type Item = #name #ty_generics;
 
@@ -141,6 +145,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics ExactSizeIterator for #iter_name #ty_generics #where_clause {
             #[inline]
             fn len(&self) -> usize {
@@ -148,6 +153,7 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics DoubleEndedIterator for #iter_name #ty_generics #where_clause {
             #[inline]
             fn next_back(&mut self) -> ::core::option::Option<<Self as Iterator>::Item> {
@@ -166,8 +172,10 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics ::core::iter::FusedIterator for #iter_name #ty_generics #where_clause { }
 
+        #[automatically_derived]
         impl #impl_generics Clone for #iter_name #ty_generics #where_clause {
             #[inline]
             fn clone(&self) -> #iter_name #ty_generics {

--- a/strum_macros/src/macros/enum_messages.rs
+++ b/strum_macros/src/macros/enum_messages.rs
@@ -112,6 +112,7 @@ pub fn enum_message_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     }
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #strum_module_path::EnumMessage for #name #ty_generics #where_clause {
             #[inline]
             fn get_message(&self) -> ::core::option::Option<&'static str> {

--- a/strum_macros/src/macros/enum_properties.rs
+++ b/strum_macros/src/macros/enum_properties.rs
@@ -87,6 +87,7 @@ pub fn enum_properties_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     );
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #strum_module_path::EnumProperty for #name #ty_generics #where_clause {
             #[inline]
             fn get_str(&self, prop: &str) -> ::core::option::Option<&'static str> {

--- a/strum_macros/src/macros/enum_try_as.rs
+++ b/strum_macros/src/macros/enum_try_as.rs
@@ -73,6 +73,7 @@ pub fn enum_try_as_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         .collect();
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #enum_name #ty_generics #where_clause {
             #(#variants)*
         }

--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -111,6 +111,7 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[allow(clippy::use_self)]
+        #[automatically_derived]
         impl #impl_generics #name #ty_generics #where_clause {
             #[doc = "Try to create [Self] from the raw representation"]
             #[inline]

--- a/strum_macros/src/macros/strings/as_ref_str.rs
+++ b/strum_macros/src/macros/strings/as_ref_str.rs
@@ -71,6 +71,7 @@ pub fn as_ref_str_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     })?;
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics ::core::convert::AsRef<str> for #name #ty_generics #where_clause {
             #[inline]
             fn as_ref(&self) -> &str {
@@ -110,6 +111,7 @@ pub fn as_static_str_inner(
 
     Ok(match trait_variant {
         GenerateTraitVariant::AsStaticStr => quote! {
+            #[automatically_derived]
             impl #impl_generics #strum_module_path::AsStaticRef<str> for #name #ty_generics #where_clause {
                 #[inline]
                 fn as_static(&self) -> &'static str {
@@ -120,6 +122,7 @@ pub fn as_static_str_inner(
             }
         },
         GenerateTraitVariant::From if !type_properties.const_into_str => quote! {
+            #[automatically_derived]
             impl #impl_generics ::core::convert::From<#name #ty_generics> for &'static str #where_clause {
                 #[inline]
                 fn from(x: #name #ty_generics) -> &'static str {
@@ -128,6 +131,7 @@ pub fn as_static_str_inner(
                     }
                 }
             }
+            #[automatically_derived]
             impl #impl_generics2 ::core::convert::From<&'_derivative_strum #name #ty_generics> for &'static str #where_clause {
                 #[inline]
                 fn from(x: &'_derivative_strum #name #ty_generics) -> &'static str {
@@ -138,6 +142,7 @@ pub fn as_static_str_inner(
             }
         },
         GenerateTraitVariant::From => quote! {
+            #[automatically_derived]
             impl #impl_generics #name #ty_generics #where_clause {
                 pub const fn into_str(&self) -> &'static str {
                     match self {
@@ -145,7 +150,7 @@ pub fn as_static_str_inner(
                     }
                 }
             }
-
+            #[automatically_derived]
             impl #impl_generics ::core::convert::From<#name #ty_generics> for &'static str #where_clause {
                 fn from(x: #name #ty_generics) -> &'static str {
                     match x {
@@ -153,6 +158,7 @@ pub fn as_static_str_inner(
                     }
                 }
             }
+            #[automatically_derived]
             impl #impl_generics2 ::core::convert::From<&'_derivative_strum #name #ty_generics> for &'static str #where_clause {
                 fn from(x: &'_derivative_strum #name #ty_generics) -> &'static str {
                     x.into_str()

--- a/strum_macros/src/macros/strings/display.rs
+++ b/strum_macros/src/macros/strings/display.rs
@@ -160,6 +160,7 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     }
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics ::core::fmt::Display for #name #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::result::Result<(), ::core::fmt::Error> {
                 match *self {

--- a/strum_macros/src/macros/strings/from_string.rs
+++ b/strum_macros/src/macros/strings/from_string.rs
@@ -171,6 +171,7 @@ pub fn from_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     let from_str = quote! {
         #[allow(clippy::use_self)]
+        #[automatically_derived]
         impl #impl_generics ::core::str::FromStr for #name #ty_generics #where_clause {
             type Err = #default_err_ty;
 
@@ -216,6 +217,7 @@ fn try_from_str(
 ) -> TokenStream {
     quote! {
         #[allow(clippy::use_self)]
+        #[automatically_derived]
         impl #impl_generics ::core::convert::TryFrom<&str> for #name #ty_generics #where_clause {
             type Error = #default_err_ty;
 

--- a/strum_macros/src/macros/strings/to_string.rs
+++ b/strum_macros/src/macros/strings/to_string.rs
@@ -57,6 +57,7 @@ pub fn to_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[allow(clippy::use_self)]
+        #[automatically_derived]
         impl #impl_generics ::std::string::ToString for #name #ty_generics #where_clause {
             fn to_string(&self) -> ::std::string::String {
                 match *self {


### PR DESCRIPTION
Hello, it's my first time trying to contribute to `strum`.

I might make some mistakes, so please don't hesitate to give me any advice.

Recently, I was using [llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) to check the test coverage of my projects. I found it won't be ignored in the coverage report. After a little while searching, I found [`#[automatically_derived]`](https://doc.rust-lang.org/reference/attributes/derive.html) could help.

> [Relevant issue](https://github.com/taiki-e/cargo-llvm-cov/issues/427)
> [Relevant codes in serde](https://github.com/serde-rs/serde/blob/babafa54d283fb087fa94f50a2cf82fa9e582a7c/serde_derive/src/ser.rs#L32)

Thank you for creating strum — it has made the Rust ecosystem even better.
