### PR TITLE
Drop needless `rustversion` dependency

### DIFF
--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -23,7 +23,6 @@ name = "strum_macros"
 heck = "0.5.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-rustversion = "1.0"
 syn = { version = "2.0", features = ["parsing"] }
 
 [dev-dependencies]

--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -658,15 +658,10 @@ pub fn enum_table(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///     Three = 3,
 /// }
 ///
-/// # #[rustversion::since(1.46)]
 /// const fn number_from_repr(d: u8) -> Option<Number> {
 ///     Number::from_repr(d)
 /// }
 ///
-/// # #[rustversion::before(1.46)]
-/// # fn number_from_repr(d: u8) -> Option<Number> {
-/// #     Number::from_repr(d)
-/// # }
 /// assert_eq!(None, number_from_repr(0));
 /// assert_eq!(Some(Number::One), number_from_repr(1));
 /// assert_eq!(None, number_from_repr(2));

--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -97,16 +97,7 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let const_if_possible = if has_additional_data {
         quote! {}
     } else {
-        #[rustversion::before(1.46)]
-        fn filter_by_rust_version(_: TokenStream) -> TokenStream {
-            quote! {}
-        }
-
-        #[rustversion::since(1.46)]
-        fn filter_by_rust_version(s: TokenStream) -> TokenStream {
-            s
-        }
-        filter_by_rust_version(quote! { const })
+        quote! { const }
     };
 
     Ok(quote! {

--- a/strum_macros/src/macros/strings/from_string.rs
+++ b/strum_macros/src/macros/strings/from_string.rs
@@ -195,18 +195,6 @@ pub fn from_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     })
 }
 
-#[rustversion::before(1.34)]
-fn try_from_str(
-    _name: &proc_macro2::Ident,
-    _impl_generics: &syn::ImplGenerics,
-    _ty_generics: &syn::TypeGenerics,
-    _where_clause: Option<&syn::WhereClause>,
-    _strum_module_path: &syn::Path,
-) -> TokenStream {
-    Default::default()
-}
-
-#[rustversion::since(1.34)]
 fn try_from_str(
     name: &proc_macro2::Ident,
     impl_generics: &syn::ImplGenerics,

--- a/strum_nostd_tests/Cargo.toml
+++ b/strum_nostd_tests/Cargo.toml
@@ -7,6 +7,3 @@ rust-version = "1.66.1"
 [dependencies]
 strum = { path = "../strum", features = ["derive"] }
 strum_macros = { path = "../strum_macros", features = [] }
-
-[dev-dependencies]
-rustversion = "1.0"

--- a/strum_nostd_tests/src/lib.rs
+++ b/strum_nostd_tests/src/lib.rs
@@ -25,13 +25,8 @@ mod tests {
     }
 
     #[test]
-    #[rustversion::since(1.34)]
     fn try_from_str_no_std() {
         use core::convert::TryFrom;
         assert_eq!(Color::Yellow, Color::try_from("yellow").unwrap());
     }
-
-    #[test]
-    #[rustversion::before(1.34)]
-    fn try_from_str_no_std() {}
 }

--- a/strum_tests/Cargo.toml
+++ b/strum_tests/Cargo.toml
@@ -15,6 +15,3 @@ strum_macros = { path = "../strum_macros", features = [] }
 clap = "=4.2.7"
 enum_variant_type = "=0.2.0"
 structopt = "=0.3.26"
-
-[dev-dependencies]
-rustversion = "1.0"

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -211,7 +211,6 @@ fn from_ref_test_complex() {
 }
 
 #[allow(dead_code)]
-#[rustversion::since(1.34)]
 #[derive(Debug, Eq, PartialEq, EnumDiscriminants, EnumVariantType)]
 #[strum_discriminants(
     name(VariantFilterAttrDiscs),
@@ -225,8 +224,7 @@ enum VariantFilterAttr {
     BrightWhite(i32),
 }
 
-#[rustversion::attr(since(1.34), test)]
-#[rustversion::since(1.34)]
+#[test]
 fn filter_variant_attributes_pass_through() {
     use std::str::FromStr;
 
@@ -245,7 +243,6 @@ fn filter_variant_attributes_pass_through() {
 }
 
 #[test]
-#[rustversion::since(1.34)]
 fn override_visibility() {
     mod private {
         use super::*;
@@ -253,27 +250,6 @@ fn override_visibility() {
         #[allow(dead_code)]
         #[derive(EnumDiscriminants)]
         #[strum_discriminants(name(PubDiscriminants), vis(pub))]
-        enum PrivateEnum {
-            VariantA(bool),
-            VariantB(bool),
-        }
-    }
-
-    assert_ne!(
-        private::PubDiscriminants::VariantA,
-        private::PubDiscriminants::VariantB,
-    );
-}
-
-#[test]
-#[rustversion::before(1.34)]
-fn override_visibility() {
-    mod private {
-        use super::*;
-
-        #[allow(dead_code)]
-        #[derive(EnumDiscriminants)]
-        #[strum_discriminants(name(PubDiscriminants), vis(r#pub))]
         enum PrivateEnum {
             VariantA(bool),
             VariantB(bool),

--- a/strum_tests/tests/from_repr.rs
+++ b/strum_tests/tests/from_repr.rs
@@ -25,7 +25,6 @@ fn simple_test() {
     assert_eq!(Week::from_repr(9), None);
 }
 
-#[rustversion::since(1.46)]
 #[test]
 fn const_test() {
     // This is to test that it works in a const fn

--- a/strum_tests/tests/from_str.rs
+++ b/strum_tests/tests/from_str.rs
@@ -34,7 +34,6 @@ enum Color2 {
     Purple { inner: String }
 }
 
-#[rustversion::since(1.34)]
 fn assert_from_str<'a, T>(a: T, from: &'a str)
 where
     T: PartialEq + std::str::FromStr + std::convert::TryFrom<&'a str> + std::fmt::Debug,
@@ -43,15 +42,6 @@ where
 {
     assert_eq!(a, T::from_str(from).unwrap());
     assert_eq!(a, std::convert::TryFrom::try_from(from).unwrap());
-}
-
-#[rustversion::before(1.34)]
-fn assert_from_str<T>(a: T, from: &str)
-where
-    T: PartialEq + std::str::FromStr + std::fmt::Debug,
-    <T as std::str::FromStr>::Err: std::fmt::Debug,
-{
-    assert_eq!(a, T::from_str(from).unwrap());
 }
 
 #[test]
@@ -183,7 +173,6 @@ fn case_insensitive_enum_no_case_insensitive() {
     assert!(CaseInsensitiveEnum::from_str("nocaseinsensitive").is_err());
 }
 
-#[rustversion::since(1.34)]
 #[test]
 fn case_insensitive_enum_no_case_insensitive_try_from() {
     assert_from_str(CaseInsensitiveEnum::NoCaseInsensitive, "NoCaseInsensitive");


### PR DESCRIPTION
This removes the `rustversion` dependency, given that all conditional compilations checked for a Rust version lower than the MSRV.