### PR TITLE
Do not capture format strings for unit enum variants in `Display`

### DIFF
--- a/strum_macros/src/macros/strings/display.rs
+++ b/strum_macros/src/macros/strings/display.rs
@@ -143,14 +143,6 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                 }
             }
             Fields::Unit => {
-                let used_vars = capture_format_strings(&output)?;
-                if !used_vars.is_empty() {
-                    return Err(syn::Error::new_spanned(
-                        &output,
-                        "Unit variants do not support interpolation",
-                    ));
-                }
-
                 quote! { #name::#ident #params => ::core::fmt::Display::fmt(#output, f) }
             }
         };

--- a/strum_tests/tests/display.rs
+++ b/strum_tests/tests/display.rs
@@ -185,3 +185,20 @@ fn transparent_string_named_field() {
         )
     );
 }
+
+#[derive(strum::Display)]
+enum CurlyBraces {
+    #[strum(to_string = "{")]
+    OpenBrace,
+    #[strum(to_string = "}")]
+    CloseBrace,
+    #[strum(to_string = "{}")]
+    OpenCloseBrace,
+}
+
+#[test]
+fn unit_variant_display_braces() {
+    assert_eq!(String::from("{"), CurlyBraces::OpenBrace.to_string());
+    assert_eq!(String::from("}"), CurlyBraces::CloseBrace.to_string());
+    assert_eq!(String::from("{}"), CurlyBraces::OpenCloseBrace.to_string());
+}

--- a/strum_tests/tests/from_str.rs
+++ b/strum_tests/tests/from_str.rs
@@ -274,3 +274,20 @@ fn case_custom_parse_error() {
         r.unwrap_err()
     );
 }
+
+#[derive(strum::EnumString, Debug, PartialEq)]
+enum CurlyBraces {
+    #[strum(serialize = "{")]
+    OpenBrace,
+    #[strum(serialize = "}")]
+    CloseBrace,
+    #[strum(serialize = "{}")]
+    OpenCloseBrace,
+}
+
+#[test]
+fn unit_variant_curly_braces() {
+    assert_eq!(CurlyBraces::from_str("{"), Ok(CurlyBraces::OpenBrace));
+    assert_eq!(CurlyBraces::from_str("}"), Ok(CurlyBraces::CloseBrace));
+    assert_eq!(CurlyBraces::from_str("{}"), Ok(CurlyBraces::OpenCloseBrace));
+}


### PR DESCRIPTION
Not sure if this is the most correct solution or not, but at least seems to resolve the issues I (and others) were having, and tests are passing. Given that unit variants in enums cannot have parameters, doesn't make sense to capture format strings for these IMO.

Added a couple more basic tests for this specific case as well.

If accepted, closes #363, and potentially #361 too?

If there are any changes you'd like made please let me know, happy to do so.