### PR TITLE
Allow any kind of passthrough attributes on `EnumDiscriminants`

### DIFF
--- a/strum_macros/src/helpers/metadata.rs
+++ b/strum_macros/src/helpers/metadata.rs
@@ -1,4 +1,3 @@
-use proc_macro2::TokenStream;
 use syn::{
     parenthesized,
     parse::{Parse, ParseStream},
@@ -126,8 +125,7 @@ pub enum EnumDiscriminantsMeta {
     Derive { _kw: kw::derive, paths: Vec<Path> },
     Name { kw: kw::name, name: Ident },
     Vis { kw: kw::vis, vis: Visibility },
-    Doc { _kw: kw::doc, doc: LitStr },
-    Other { path: Path, nested: TokenStream },
+    Other { passthrough_meta: Meta },
 }
 
 impl Parse for EnumDiscriminantsMeta {
@@ -153,17 +151,9 @@ impl Parse for EnumDiscriminantsMeta {
             parenthesized!(content in input);
             let vis = content.parse()?;
             Ok(EnumDiscriminantsMeta::Vis { kw, vis })
-        } else if input.peek(kw::doc) {
-            let _kw = input.parse()?;
-            input.parse::<Token![=]>()?;
-            let doc = input.parse()?;
-            Ok(EnumDiscriminantsMeta::Doc { _kw, doc })
         } else {
-            let path = input.parse()?;
-            let content;
-            parenthesized!(content in input);
-            let nested = content.parse()?;
-            Ok(EnumDiscriminantsMeta::Other { path, nested })
+            let passthrough_meta = input.parse()?;
+            Ok(EnumDiscriminantsMeta::Other { passthrough_meta })
         }
     }
 }

--- a/strum_macros/src/helpers/type_props.rs
+++ b/strum_macros/src/helpers/type_props.rs
@@ -1,7 +1,6 @@
 use proc_macro2::TokenStream;
-use quote::quote;
 use std::default::Default;
-use syn::{parse_quote, DeriveInput, Ident, LitStr, Path, Visibility};
+use syn::{parse_quote, DeriveInput, Ident, LitStr, Meta, Path, Visibility};
 
 use super::case_style::CaseStyle;
 use super::metadata::{DeriveInputExt, EnumDiscriminantsMeta, EnumMeta};
@@ -20,14 +19,13 @@ pub struct StrumTypeProperties {
     pub crate_module_path: Option<Path>,
     pub discriminant_derives: Vec<Path>,
     pub discriminant_name: Option<Ident>,
-    pub discriminant_others: Vec<TokenStream>,
+    pub discriminant_others: Vec<Meta>,
     pub discriminant_vis: Option<Visibility>,
     pub use_phf: bool,
     pub prefix: Option<LitStr>,
     pub suffix: Option<LitStr>,
     pub enum_repr: Option<TokenStream>,
     pub const_into_str: bool,
-    pub discriminant_docs: Vec<LitStr>,
 }
 
 impl HasTypeProperties for DeriveInput {
@@ -150,11 +148,8 @@ impl HasTypeProperties for DeriveInput {
                     vis_kw = Some(kw);
                     output.discriminant_vis = Some(vis);
                 }
-                EnumDiscriminantsMeta::Doc { doc, .. } => {
-                    output.discriminant_docs.push(doc);
-                }
-                EnumDiscriminantsMeta::Other { path, nested } => {
-                    output.discriminant_others.push(quote! { #path(#nested) });
+                EnumDiscriminantsMeta::Other { passthrough_meta } => {
+                    output.discriminant_others.push(passthrough_meta);
                 }
             }
         }

--- a/strum_tests/src/lib.rs
+++ b/strum_tests/src/lib.rs
@@ -13,3 +13,40 @@ pub enum Color {
     #[strum(disabled)]
     Green(String),
 }
+
+/// A bunch of errors
+///
+/// This will not work:
+///
+/// ```compile_fail
+/// # use strum_tests::{Errors, ErrorsDiscriminants};
+/// fn expect_path_error(error: &Errors) {
+///     let discriminant: ErrorsDiscriminants = error.into();
+///     match discriminant {
+///         ErrorsDiscriminants::PathError => (),
+///         ErrorsDiscriminants::NotFound => panic!("should be a path error"),
+///     }
+/// }
+/// ```
+///
+/// This will work:
+///
+/// ```
+/// # use strum_tests::{Errors, ErrorsDiscriminants};
+/// fn expect_path_error(error: &Errors) {
+///     let discriminant: ErrorsDiscriminants = error.into();
+///     match discriminant {
+///         ErrorsDiscriminants::PathError => (),
+///         ErrorsDiscriminants::NotFound => panic!("should be a path error"),
+///         _ => panic!("unknown error, should be a path error"),
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, EnumDiscriminants)]
+#[non_exhaustive]
+#[strum_discriminants(doc = "Discriminants-only version of a bunch of errors")]
+#[strum_discriminants(non_exhaustive)]
+pub enum Errors {
+    NotFound,
+    PathError(String),
+}

--- a/strum_tests/tests/enum_discriminants.rs
+++ b/strum_tests/tests/enum_discriminants.rs
@@ -5,6 +5,7 @@ use strum::{
     Display, EnumDiscriminants, EnumIter, EnumMessage, EnumString, FromRepr, IntoEnumIterator,
     VariantArray,
 };
+use strum_tests::{Errors, ErrorsDiscriminants};
 
 mod core {} // ensure macros call `::core`
 
@@ -339,6 +340,17 @@ fn with_explicit_discriminant_value() {
         142,
         WithExplicitDicriminantValueDiscriminants::Variant0 as u8
     );
+}
+
+#[test]
+fn non_exhaustive_enum() {
+    let error = Errors::PathError("some_path".into());
+    let error_discriminant: ErrorsDiscriminants = error.into();
+    match error_discriminant {
+        ErrorsDiscriminants::NotFound => unreachable!(),
+        ErrorsDiscriminants::PathError => (),
+        _ => unreachable!(),
+    }
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
This PR adds support for two new kinds of passthrough attributes on `EnumDiscriminants`:

- Path only (ex: `#[strum_discriminants(non_exhaustive)]`)
- Name/value (ex: `#[strum_discriminants(doc = "foo")]`)

This has been ported from https://github.com/clechasseur/gratte/pull/15.