### PR TITLE
Add missing `#[automatically_derived]`

### DIFF
--- a/strum_macros/src/macros/enum_table.rs
+++ b/strum_macros/src/macros/enum_table.rs
@@ -122,6 +122,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             #(#snake_idents: T,)*
         }
 
+        #[automatically_derived]
         impl<T: Clone> #table_name<T> {
             #[doc = #doc_filled]
             #vis fn filled(value: T) -> #table_name<T> {
@@ -131,6 +132,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[automatically_derived]
         impl<T> #table_name<T> {
             #[doc = #doc_new]
             #[inline]
@@ -160,6 +162,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
         }
 
+        #[automatically_derived]
         impl<T> ::core::ops::Index<#name> for #table_name<T> {
             type Output = T;
 
@@ -172,6 +175,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[automatically_derived]
         impl<T> ::core::ops::IndexMut<#name> for #table_name<T> {
             #[inline]
             fn index_mut(&mut self, idx: #name) -> &mut T {
@@ -182,6 +186,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[automatically_derived]
         impl<T> #table_name<::core::option::Option<T>> {
             #[doc = #doc_option_all]
             #[inline]
@@ -198,6 +203,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[automatically_derived]
         impl<T, E> #table_name<::core::result::Result<T, E>> {
             #[doc = #doc_result_all_ok]
             #[inline]

--- a/strum_macros/src/macros/enum_try_as.rs
+++ b/strum_macros/src/macros/enum_try_as.rs
@@ -36,6 +36,7 @@ pub fn enum_try_as_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                     let mut_fn_name = format_ident!("try_as_{}_mut", snakify(&variant_name.to_string()));
 
                     Some(quote! {
+                        #[automatically_derived]
                         #[must_use]
                         #[inline]
                         pub fn #move_fn_name(self) -> ::core::option::Option<(#(#types),*)> {
@@ -45,6 +46,7 @@ pub fn enum_try_as_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                             }
                         }
 
+                        #[automatically_derived]
                         #[must_use]
                         #[inline]
                         pub const fn #ref_fn_name(&self) -> ::core::option::Option<(#(&#types),*)> {
@@ -54,6 +56,7 @@ pub fn enum_try_as_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                             }
                         }
 
+                        #[automatically_derived]
                         #[must_use]
                         #[inline]
                         pub fn #mut_fn_name(&mut self) -> ::core::option::Option<(#(&mut #types),*)> {

--- a/strum_macros/src/macros/enum_variant_array.rs
+++ b/strum_macros/src/macros/enum_variant_array.rs
@@ -27,6 +27,7 @@ pub fn static_variants_array_inner(ast: &DeriveInput) -> syn::Result<TokenStream
         .collect::<syn::Result<Vec<_>>>()?;
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #strum_module_path::VariantArray for #name #ty_generics #where_clause {
             const VARIANTS: &'static [Self] = &[ #(#name::#idents),* ];
         }

--- a/strum_macros/src/macros/enum_variant_names.rs
+++ b/strum_macros/src/macros/enum_variant_names.rs
@@ -31,6 +31,7 @@ pub fn enum_variant_names_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         .collect::<syn::Result<Vec<LitStr>>>()?;
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #strum_module_path::VariantNames for #name #ty_generics #where_clause {
             const VARIANTS: &'static [&'static str] = &[ #(#names),* ];
         }


### PR DESCRIPTION
https://github.com/Peternator7/strum/pull/444 added `#[automatically_derived]` to some of the code generated by the derive macros, but not all. This PR adds the missing ones.

This has been ported from https://github.com/clechasseur/gratte/pull/24 (at least the part not already present).