### PR TITLE
Bump MSRV to v1.71

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.66.1
+          - 1.71.1
           - stable
           - beta
           - nightly

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Strum is a set of macros and traits for working with enums and strings easier in
 
 # Compatibility
 
-Strum is currently compatible with versions of rustc >= 1.66.1. Pull Requests that improve compatibility with older
+Strum is currently compatible with versions of rustc >= 1.71.1. Pull Requests that improve compatibility with older
 versions are welcome. The project goal is to support a rust version for at least 2 years after release 
 and even longer is preferred since this project changes slowly.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,10 +38,10 @@ environment:
 ### MSVC Toolchains ###
 
   # MSRC 64-bit MSVC
-    - channel: 1.66.1
+    - channel: 1.71.1
       target: x86_64-pc-windows-msvc
   # MSRC 32-bit MSVC
-    - channel: 1.66.1
+    - channel: 1.71.1
       target: i686-pc-windows-msvc
   # Stable 64-bit MSVC
     - channel: stable
@@ -106,7 +106,7 @@ test_script:
 for:
 - matrix:
     only:
-      - channel: 1.66.1
+      - channel: 1.71.1
 
   test_script:
   - cargo test --verbose %cargoflags%

--- a/strum/Cargo.toml
+++ b/strum/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/strum"
 homepage = "https://github.com/Peternator7/strum"
 repository = "https://github.com/Peternator7/strum"
 readme = "../README.md"
-rust-version = "1.66.1"
+rust-version = "1.71"
 
 [dependencies]
 strum_macros = { path = "../strum_macros", optional = true, version = "0.27" }

--- a/strum_macros/Cargo.toml
+++ b/strum_macros/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/strum"
 homepage = "https://github.com/Peternator7/strum"
 repository = "https://github.com/Peternator7/strum"
 readme = "../README.md"
-rust-version = "1.66.1"
+rust-version = "1.71"
 
 [lib]
 proc-macro = true

--- a/strum_nostd_tests/Cargo.toml
+++ b/strum_nostd_tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "strum_nostd_tests"
 version = "0.27.1"
 edition = "2021"
-rust-version = "1.66.1"
+rust-version = "1.71"
 
 [dependencies]
 strum = { path = "../strum", features = ["derive"] }

--- a/strum_tests/Cargo.toml
+++ b/strum_tests/Cargo.toml
@@ -3,7 +3,7 @@ name = "strum_tests"
 version = "0.27.1"
 edition = "2021"
 authors = ["Peter Glotfelty <peglotfe@microsoft.com>"]
-rust-version = "1.66.1"
+rust-version = "1.71"
 
 [features]
 default = []


### PR DESCRIPTION
Required to keep-up with the latest MSRV bump in `syn` and `windows-sys`.