### PR TITLE
fix: Ignore deprecation warnings on generated code

### DIFF
--- a/strum_macros/src/macros/enum_discriminants.rs
+++ b/strum_macros/src/macros/enum_discriminants.rs
@@ -172,6 +172,8 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let impl_from = quote! {
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics ::core::convert::From< #name #ty_generics > for #discriminants_name #where_clause {
             #[inline]
@@ -191,6 +193,8 @@ pub fn enum_discriminants_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         let (impl_generics, _, _) = generics.split_for_impl();
 
         quote! {
+            #[allow(deprecated)]
+            #[allow(unreachable_code)]
             #[automatically_derived]
             impl #impl_generics ::core::convert::From< #enum_life #name #ty_generics > for #discriminants_name #where_clause {
                 #[inline]

--- a/strum_macros/src/macros/enum_is.rs
+++ b/strum_macros/src/macros/enum_is.rs
@@ -39,6 +39,8 @@ pub fn enum_is_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         .collect();
 
     Ok(quote! {
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics #enum_name  #ty_generics #where_clause {
             #(#variants)*

--- a/strum_macros/src/macros/enum_iter.rs
+++ b/strum_macros/src/macros/enum_iter.rs
@@ -91,6 +91,8 @@ pub fn enum_iter_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics #iter_name #ty_generics #where_clause {
             fn get(&self, idx: usize) -> ::core::option::Option<#name #ty_generics> {

--- a/strum_macros/src/macros/enum_messages.rs
+++ b/strum_macros/src/macros/enum_messages.rs
@@ -112,6 +112,8 @@ pub fn enum_message_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     }
 
     Ok(quote! {
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics #strum_module_path::EnumMessage for #name #ty_generics #where_clause {
             #[inline]

--- a/strum_macros/src/macros/enum_properties.rs
+++ b/strum_macros/src/macros/enum_properties.rs
@@ -87,6 +87,8 @@ pub fn enum_properties_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     );
 
     Ok(quote! {
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics #strum_module_path::EnumProperty for #name #ty_generics #where_clause {
             #[inline]

--- a/strum_macros/src/macros/enum_table.rs
+++ b/strum_macros/src/macros/enum_table.rs
@@ -132,6 +132,8 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl<T> #table_name<T> {
             #[doc = #doc_new]
@@ -162,6 +164,8 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
         }
 
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl<T> ::core::ops::Index<#name> for #table_name<T> {
             type Output = T;
@@ -175,6 +179,8 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl<T> ::core::ops::IndexMut<#name> for #table_name<T> {
             #[inline]

--- a/strum_macros/src/macros/enum_try_as.rs
+++ b/strum_macros/src/macros/enum_try_as.rs
@@ -76,6 +76,8 @@ pub fn enum_try_as_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         .collect();
 
     Ok(quote! {
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics #enum_name #ty_generics #where_clause {
             #(#variants)*

--- a/strum_macros/src/macros/enum_variant_array.rs
+++ b/strum_macros/src/macros/enum_variant_array.rs
@@ -27,6 +27,8 @@ pub fn static_variants_array_inner(ast: &DeriveInput) -> syn::Result<TokenStream
         .collect::<syn::Result<Vec<_>>>()?;
 
     Ok(quote! {
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics #strum_module_path::VariantArray for #name #ty_generics #where_clause {
             const VARIANTS: &'static [Self] = &[ #(#name::#idents),* ];

--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -102,6 +102,8 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[allow(clippy::use_self)]
+        #[allow(deprecated)] // omit warnings on deprecated fields/variants
+        #[allow(unreachable_code)] // omit warnings for `!` and other unreachable types
         #[automatically_derived]
         impl #impl_generics #name #ty_generics #where_clause {
             #[doc = "Try to create [Self] from the raw representation"]

--- a/strum_macros/src/macros/strings/as_ref_str.rs
+++ b/strum_macros/src/macros/strings/as_ref_str.rs
@@ -74,6 +74,8 @@ pub fn as_ref_str_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     })?;
 
     Ok(quote! {
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics ::core::convert::AsRef<str> for #name #ty_generics #where_clause {
             #[inline]
@@ -114,6 +116,8 @@ pub fn as_static_str_inner(
 
     Ok(match trait_variant {
         GenerateTraitVariant::AsStaticStr => quote! {
+            #[allow(deprecated)]
+            #[allow(unreachable_code)]
             #[automatically_derived]
             impl #impl_generics #strum_module_path::AsStaticRef<str> for #name #ty_generics #where_clause {
                 #[inline]
@@ -125,6 +129,8 @@ pub fn as_static_str_inner(
             }
         },
         GenerateTraitVariant::From if !type_properties.const_into_str => quote! {
+            #[allow(deprecated)]
+            #[allow(unreachable_code)]
             #[automatically_derived]
             impl #impl_generics ::core::convert::From<#name #ty_generics> for &'static str #where_clause {
                 #[inline]
@@ -134,6 +140,8 @@ pub fn as_static_str_inner(
                     }
                 }
             }
+            #[allow(deprecated)]
+            #[allow(unreachable_code)]
             #[automatically_derived]
             impl #impl_generics2 ::core::convert::From<&'_derivative_strum #name #ty_generics> for &'static str #where_clause {
                 #[inline]
@@ -145,6 +153,8 @@ pub fn as_static_str_inner(
             }
         },
         GenerateTraitVariant::From => quote! {
+            #[allow(deprecated)]
+            #[allow(unreachable_code)]
             #[automatically_derived]
             impl #impl_generics #name #ty_generics #where_clause {
                 pub const fn into_str(&self) -> &'static str {
@@ -153,6 +163,8 @@ pub fn as_static_str_inner(
                     }
                 }
             }
+            #[allow(deprecated)]
+            #[allow(unreachable_code)]
             #[automatically_derived]
             impl #impl_generics ::core::convert::From<#name #ty_generics> for &'static str #where_clause {
                 fn from(x: #name #ty_generics) -> &'static str {
@@ -161,6 +173,8 @@ pub fn as_static_str_inner(
                     }
                 }
             }
+            #[allow(deprecated)]
+            #[allow(unreachable_code)]
             #[automatically_derived]
             impl #impl_generics2 ::core::convert::From<&'_derivative_strum #name #ty_generics> for &'static str #where_clause {
                 fn from(x: &'_derivative_strum #name #ty_generics) -> &'static str {

--- a/strum_macros/src/macros/strings/display.rs
+++ b/strum_macros/src/macros/strings/display.rs
@@ -163,6 +163,8 @@ pub fn display_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     }
 
     Ok(quote! {
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics ::core::fmt::Display for #name #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::result::Result<(), ::core::fmt::Error> {

--- a/strum_macros/src/macros/strings/from_string.rs
+++ b/strum_macros/src/macros/strings/from_string.rs
@@ -182,6 +182,8 @@ pub fn from_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let from_impl = if is_infallible && !has_custom_err_ty {
         quote! {
             #[allow(clippy::use_self)]
+            #[allow(deprecated)]
+            #[allow(unreachable_code)]
             #[automatically_derived]
             impl #impl_generics ::core::convert::From<&str> for #name #ty_generics #where_clause {
                 #[inline]
@@ -193,6 +195,8 @@ pub fn from_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     } else {
         quote! {
             #[allow(clippy::use_self)]
+            #[allow(deprecated)]
+            #[allow(unreachable_code)]
             #[automatically_derived]
             impl #impl_generics ::core::convert::TryFrom<&str> for #name #ty_generics #where_clause {
                 type Error = #err_ty;
@@ -209,6 +213,8 @@ pub fn from_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     let from_str = quote! {
         #[allow(clippy::use_self)]
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics ::core::str::FromStr for #name #ty_generics #where_clause {
             type Err = #err_ty;

--- a/strum_macros/src/macros/strings/to_string.rs
+++ b/strum_macros/src/macros/strings/to_string.rs
@@ -60,6 +60,8 @@ pub fn to_string_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[allow(clippy::use_self)]
+        #[allow(deprecated)]
+        #[allow(unreachable_code)]
         #[automatically_derived]
         impl #impl_generics ::std::string::ToString for #name #ty_generics #where_clause {
             fn to_string(&self) -> ::std::string::String {

--- a/strum_tests/tests/macro_warnings.rs
+++ b/strum_tests/tests/macro_warnings.rs
@@ -1,0 +1,42 @@
+//! Test that derive macro implementations do not emit deprecated or unreachable
+//! code warnings.
+#![deny(deprecated, unreachable_code)]
+
+use strum_macros::{
+    AsRefStr, Display, EnumCount, EnumDiscriminants, EnumIs, EnumIter, EnumMessage, EnumProperty,
+    EnumString, EnumTable, EnumTryAs, FromRepr, IntoStaticStr, VariantArray,
+};
+
+#[derive(
+    Debug,
+    Display,
+    AsRefStr,
+    EnumCount,
+    EnumDiscriminants,
+    EnumIs,
+    EnumMessage,
+    EnumProperty,
+    EnumTryAs,
+    IntoStaticStr,
+)]
+pub enum Color {
+    Red,
+    Blue {
+        hue: usize,
+    },
+    #[strum(default)]
+    Green(f64),
+    // Deprecated variant
+    #[deprecated]
+    Purple(String),
+    // Unreachable variant
+    Olo(std::convert::Infallible),
+}
+
+#[derive(VariantArray, EnumString, EnumIter, EnumTable, FromRepr)]
+pub enum Bar {
+    A,
+    B,
+    #[deprecated]
+    C,
+}


### PR DESCRIPTION
Deprecating a field or variant produced un-ignorable warnings in the code generated by the derive macros (the only solution was to global `#![allow(deprecated)]`s for the whole module).

Fixes https://github.com/Peternator7/strum/issues/404.

Added a test that fails to compile without the fix.