### PR TITLE
Fix clippy::too_many_arguments on EnumTable derive

### DIFF
--- a/strum_macros/src/macros/enum_table.rs
+++ b/strum_macros/src/macros/enum_table.rs
@@ -136,6 +136,7 @@ pub fn enum_table_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         impl<T> #table_name<T> {
             #[doc = #doc_new]
             #[inline]
+            #[allow(clippy::too_many_arguments)]
             #vis fn new(
                 #(#snake_idents: T,)*
             ) -> #table_name<T> {

--- a/strum_tests/tests/enum_variant_table.rs
+++ b/strum_tests/tests/enum_variant_table.rs
@@ -101,3 +101,18 @@ fn transform() {
     let all_two = ColorTable::filled(2);
     assert_eq!(all_two.transform(|_, n| *n * 2), ColorTable::filled(4));
 }
+
+// 8+ variants would exceed clippy's too_many_arguments threshold on the generated `new`
+// if the macro didn't allow the lint
+#[derive(EnumTable)]
+#[allow(dead_code)]
+enum Wide {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+}


### PR DESCRIPTION
Deriving EnumTable on an enum creates a *Table::new with one argument per variant. For enums with many variants, this hits clippy's too_many_arguments lint, which cannot be disabled outside the macro without a module/crate level override.