### PR TITLE
Update from_repr to explicitly use ::core::option::Option as its return type.

### DIFF
--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -106,7 +106,7 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         impl #impl_generics #name #ty_generics #where_clause {
             #[doc = "Try to create [Self] from the raw representation"]
             #[inline]
-            #vis #const_if_possible fn from_repr(discriminant: #discriminant_type) -> Option<#name #ty_generics> {
+            #vis #const_if_possible fn from_repr(discriminant: #discriminant_type) -> ::core::option::Option<#name #ty_generics> {
                 #(#constant_defs)*
                 match discriminant {
                     #(#arms),*


### PR DESCRIPTION
This avoids potential name conflicts when a custom Option type is in scope and ensures that from_repr consistently refers to Rust's standard Option type.