### PR TITLE
from_repr no longer rejects lifetimes

### DIFF
--- a/strum_macros/src/lib.rs
+++ b/strum_macros/src/lib.rs
@@ -640,9 +640,6 @@ pub fn enum_table(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// to allow `match` statements in `const fn`. The no additional data requirement is due to the
 /// inability to use `Default::default()` in a `const fn`.
 ///
-/// You cannot derive `FromRepr` on any type with a lifetime bound (`<'a>`) because the function would surely
-/// create [unbounded lifetimes](https://doc.rust-lang.org/nightly/nomicon/unbounded-lifetimes.html).
-///
 /// ```
 ///
 /// use strum_macros::FromRepr;

--- a/strum_macros/src/macros/from_repr.rs
+++ b/strum_macros/src/macros/from_repr.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Data, DeriveInput, Fields, Type};
 
@@ -6,8 +6,7 @@ use crate::helpers::{non_enum_error, HasStrumVariantProperties, HasTypePropertie
 
 pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
-    let gen = &ast.generics;
-    let (impl_generics, ty_generics, where_clause) = gen.split_for_impl();
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let vis = &ast.vis;
 
     let mut discriminant_type: Type = syn::parse("usize".parse().unwrap()).unwrap();
@@ -29,14 +28,6 @@ pub fn from_repr_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
                 }
             }
         }
-    }
-
-    if gen.lifetimes().count() > 0 {
-        return Err(syn::Error::new(
-            Span::call_site(),
-            "This macro doesn't support enums with lifetimes. \
-             The resulting enums would be unbounded.",
-        ));
     }
 
     let variants = match &ast.data {

--- a/strum_tests/tests/from_repr.rs
+++ b/strum_tests/tests/from_repr.rs
@@ -64,3 +64,19 @@ fn crate_module_path_test() {
     assert_eq!(Week::from_repr(6), Some(Week::Saturday));
     assert_eq!(Week::from_repr(7), None);
 }
+
+#[derive(Debug, FromRepr, PartialEq)]
+#[repr(u8)]
+enum Data<'a> {
+    Version1,
+    Version2,
+    Data(&'a str),
+}
+
+#[test]
+fn lifetime_test() {
+    assert_eq!(Data::from_repr(0), Some(Data::Version1));
+    assert_eq!(Data::from_repr(1), Some(Data::Version2));
+    assert_eq!(Data::from_repr(2), Some(Data::Data("")));
+    assert_eq!(Data::from_repr(3), None);
+}


### PR DESCRIPTION
`FromRepr` currently rejects types with lifetimes, but there's really no reason to (this is clear from how the generated implementation is 100% safe code). This PR removes this limitation. This also makes `FromRepr` more consistent with `FromStr`, which already has no problem with types with lifetimes.